### PR TITLE
Hot reloading of modules for immediate code changes

### DIFF
--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -27,7 +27,15 @@ from bpy.props import *
 import bl_operators
 from bpy.types import Menu, Operator, UIList, AddonPreferences
 
-from cam import ui, ops,curvecamtools,curvecamequation, utils, simple, polygon_utils_cam  # , post_processors
+import importlib
+camModules=["ui", "ops","curvecamtools","curvecamequation", "utils", "simple", "polygon_utils_cam"] # , post_processors
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+        pass
+
 import numpy
 
 from shapely import geometry as sgeometry

--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -36,8 +36,6 @@ for mod in camModules:
         exec("importlib.reload("+modName+")")
     except:
         print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
-        
-from cam import curvecamequation
 
 import numpy
 

--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -28,14 +28,16 @@ import bl_operators
 from bpy.types import Menu, Operator, UIList, AddonPreferences
 
 import importlib
-camModules=["ui", "ops","curvecamtools","curvecamequation", "utils", "simple", "polygon_utils_cam"] # , post_processors
+camModules=["ui", "ops", "curvecamtools", "curvecamequation", "utils", "simple", "polygon_utils_cam"] # , post_processors
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-    	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
+        
+from cam import curvecamequation
 
 import numpy
 

--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -34,6 +34,7 @@ for mod in camModules:
         __import__("cam."+mod)
         importlib.reload(mod)
     except:
+    	print("SOMETHING AWFUL HAPPENED")
         pass
 
 import numpy

--- a/scripts/addons/cam/bridges.py
+++ b/scripts/addons/cam/bridges.py
@@ -28,8 +28,7 @@ from cam import utils
 try:
 	importlib.reload(utils)
 except:
-	print("SOMETHING AWFUL HAPPENED")
-	pass
+    print("PROBLEM RELOADING MODULE cam.utils AT "+__name__)
 
 import mathutils
 import math

--- a/scripts/addons/cam/bridges.py
+++ b/scripts/addons/cam/bridges.py
@@ -23,7 +23,14 @@
 import bpy
 from bpy.props import *
 
+import importlib
 from cam import utils
+try:
+	importlib.reload(utils)
+except:
+	print("SOMETHING AWFUL HAPPENED")
+	pass
+
 import mathutils
 import math
 

--- a/scripts/addons/cam/chunk.py
+++ b/scripts/addons/cam/chunk.py
@@ -28,11 +28,11 @@ import importlib
 camModules=["polygon_utils_cam", "simple"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 from cam.simple import *
 
 import math

--- a/scripts/addons/cam/chunk.py
+++ b/scripts/addons/cam/chunk.py
@@ -23,8 +23,18 @@
 import shapely
 from shapely.geometry import polygon as spolygon
 from shapely import geometry as sgeometry
-from cam import polygon_utils_cam
+
+import importlib
+camModules=["polygon_utils_cam", "simple"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
 from cam.simple import *
+
 import math
 
 def Rotate_pbyp(originp, p, ang): ## rotate point around another point with angle

--- a/scripts/addons/cam/collision.py
+++ b/scripts/addons/cam/collision.py
@@ -22,8 +22,14 @@
 import bpy
 import time
 
+import importlib
 from cam import simple
 from cam.simple import *
+try:
+	importlib.reload(simple)
+except:
+	print("SOMETHING AWFUL HAPPENED")
+	pass
 
 BULLET_SCALE = 10000  # this is a constant for scaling the rigidbody collision world for higher precision from bullet library
 CUTTER_OFFSET = (-5 * BULLET_SCALE, -5 * BULLET_SCALE,

--- a/scripts/addons/cam/collision.py
+++ b/scripts/addons/cam/collision.py
@@ -28,8 +28,7 @@ from cam.simple import *
 try:
 	importlib.reload(simple)
 except:
-	print("SOMETHING AWFUL HAPPENED")
-	pass
+	print("PROBLEM RELOADING MODULE cam.simple AT "+__name__)
 
 BULLET_SCALE = 10000  # this is a constant for scaling the rigidbody collision world for higher precision from bullet library
 CUTTER_OFFSET = (-5 * BULLET_SCALE, -5 * BULLET_SCALE,

--- a/scripts/addons/cam/curvecamequation.py
+++ b/scripts/addons/cam/curvecamequation.py
@@ -29,11 +29,11 @@ import importlib
 camModules=["utils", "parametric"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 	
 import math
 from Equation import Expression

--- a/scripts/addons/cam/curvecamequation.py
+++ b/scripts/addons/cam/curvecamequation.py
@@ -24,7 +24,17 @@
 import bpy
 from bpy.props import *
 
-from cam import utils, parametric
+
+import importlib
+camModules=["utils", "parametric"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
+	
 import math
 from Equation import Expression
 import numpy as np

--- a/scripts/addons/cam/curvecamtools.py
+++ b/scripts/addons/cam/curvecamtools.py
@@ -27,7 +27,16 @@ from bpy.props import *
 from bpy.types import Operator
 from bpy_extras.io_utils import ImportHelper
 
-from cam import utils, pack, polygon_utils_cam, simple, gcodepath, bridges, parametric, gcodeimportparser
+import importlib
+camModules=["utils", "pack", "polygon_utils_cam", "simple", "gcodepath", "bridges", "parametric", "gcodeimportparser"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
+        
 import shapely
 import mathutils
 import math

--- a/scripts/addons/cam/curvecamtools.py
+++ b/scripts/addons/cam/curvecamtools.py
@@ -31,11 +31,11 @@ import importlib
 camModules=["utils", "pack", "polygon_utils_cam", "simple", "gcodepath", "bridges", "parametric", "gcodeimportparser"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
         
 import shapely
 import mathutils

--- a/scripts/addons/cam/gcodepath.py
+++ b/scripts/addons/cam/gcodepath.py
@@ -35,11 +35,11 @@ import importlib
 camModules=["chunk", "collision", "simple", "utils", "strategy", "pattern", "polygon_utils_cam", "image_utils", "nc.iso"]
 for mod in camModules:
     try:
-    	__import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 from cam.chunk import *
 from cam.collision import *
 from cam.simple import *

--- a/scripts/addons/cam/gcodepath.py
+++ b/scripts/addons/cam/gcodepath.py
@@ -31,28 +31,21 @@ from bpy.props import *
 
 import numpy
 
-from cam import chunk
+import importlib
+camModules=["chunk", "collision", "simple", "utils", "strategy", "pattern", "polygon_utils_cam", "image_utils", "nc.iso"]
+for mod in camModules:
+    try:
+    	__import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
 from cam.chunk import *
-
-from cam import collision
 from cam.collision import *
-
-from cam import simple
 from cam.simple import *
-
-from cam import utils
-from cam import strategy
-
-from cam import pattern
 from cam.pattern import *
-
-from cam import polygon_utils_cam
 from cam.polygon_utils_cam import *
-
-from cam import image_utils
 from cam.image_utils import *
-
-from cam.nc import iso
 
 
 def pointonline(a,b,c,tolerence):

--- a/scripts/addons/cam/image_utils.py
+++ b/scripts/addons/cam/image_utils.py
@@ -33,11 +33,11 @@ import importlib
 camModules=["simple", "chunk", "simulation"]
 for mod in camModules:
     try:
-    	__import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 from cam.simple import *
 from cam.chunk import *
 

--- a/scripts/addons/cam/image_utils.py
+++ b/scripts/addons/cam/image_utils.py
@@ -28,12 +28,18 @@ import curve_simplify
 import mathutils
 from mathutils import *
 
-from cam import simple
-from cam.simple import *
-from cam import chunk
-from cam.chunk import *
-from cam import simulation
 
+import importlib
+camModules=["simple", "chunk", "simulation"]
+for mod in camModules:
+    try:
+    	__import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
+from cam.simple import *
+from cam.chunk import *
 
 def getCircle(r, z):
     car = numpy.array((0), dtype=float)

--- a/scripts/addons/cam/ops.py
+++ b/scripts/addons/cam/ops.py
@@ -27,11 +27,22 @@ from bpy.props import *
 from bpy_extras.io_utils import ImportHelper
 
 import subprocess, os, threading
-from cam import utils, pack, polygon_utils_cam, simple,gcodepath,bridges, simulation
+
+import cam
+import importlib
+camModules=["utils", "pack", "polygon_utils_cam", "simple,gcodepath", "bridges", "simulation"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
+
 import shapely
 import mathutils
 import math
-import cam
+
 
 
 class threadCom:  # object passed to threads to read background process stdout info

--- a/scripts/addons/cam/ops.py
+++ b/scripts/addons/cam/ops.py
@@ -30,14 +30,14 @@ import subprocess, os, threading
 
 import cam
 import importlib
-camModules=["utils", "pack", "polygon_utils_cam", "simple,gcodepath", "bridges", "simulation"]
+camModules=["utils", "pack", "polygon_utils_cam", "simple", "gcodepath", "bridges", "simulation"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 
 import shapely
 import mathutils

--- a/scripts/addons/cam/pack.py
+++ b/scripts/addons/cam/pack.py
@@ -20,7 +20,16 @@
 # ***** END GPL LICENCE BLOCK *****
 
 import bpy
-from cam import utils, simple, polygon_utils_cam
+import importlib
+camModules=["utils", "simple", "polygon_utils_cam"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
+
 import shapely
 from shapely import geometry as sgeometry
 from shapely import affinity, prepared

--- a/scripts/addons/cam/pack.py
+++ b/scripts/addons/cam/pack.py
@@ -24,11 +24,11 @@ import importlib
 camModules=["utils", "simple", "polygon_utils_cam"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 
 import shapely
 from shapely import geometry as sgeometry

--- a/scripts/addons/cam/pattern.py
+++ b/scripts/addons/cam/pattern.py
@@ -24,19 +24,18 @@ import mathutils
 from mathutils import *
 
 import importlib
-from cam import simple, chunk
+camModules=["simple", "chunk", "polygon_utils_cam"]
+for mod in camModules:
+	try:
+		modName=mod.split(".")[-1]
+		exec(modName + "=importlib.import_module('cam."+ mod+"')")
+		exec("importlib.reload("+modName+")")
+	except:
+		print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 from cam.simple import *
 from cam.chunk import *
-from cam import polygon_utils_cam
 from cam.polygon_utils_cam import *
-try:
-	importlib.reload(simple)
-	importlib.reload(chunk)
-	importlib.reload(polygon_utils_cam)
-except:
-	print("SOMETHING AWFUL HAPPENED")
-	pass
-	
+
 import shapely
 from shapely import geometry as sgeometry
 import numpy

--- a/scripts/addons/cam/pattern.py
+++ b/scripts/addons/cam/pattern.py
@@ -23,12 +23,20 @@ import time
 import mathutils
 from mathutils import *
 
-
+import importlib
 from cam import simple, chunk
 from cam.simple import *
 from cam.chunk import *
 from cam import polygon_utils_cam
 from cam.polygon_utils_cam import *
+try:
+	importlib.reload(simple)
+	importlib.reload(chunk)
+	importlib.reload(polygon_utils_cam)
+except:
+	print("SOMETHING AWFUL HAPPENED")
+	pass
+	
 import shapely
 from shapely import geometry as sgeometry
 import numpy

--- a/scripts/addons/cam/simulation.py
+++ b/scripts/addons/cam/simulation.py
@@ -32,11 +32,11 @@ import importlib
 camModules=["utils", "simple", "image_utils"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 
 
 def createSimulationObject(name, operations, i):

--- a/scripts/addons/cam/simulation.py
+++ b/scripts/addons/cam/simulation.py
@@ -26,12 +26,17 @@ import mathutils
 import math
 import time
 from bpy.props import *
-from cam import utils
 import numpy as np
 
-from cam import simple
-from cam import image_utils
-
+import importlib
+camModules=["utils", "simple", "image_utils"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
 
 
 def createSimulationObject(name, operations, i):

--- a/scripts/addons/cam/slice.py
+++ b/scripts/addons/cam/slice.py
@@ -28,8 +28,7 @@ from cam import utils
 try:
 	importlib.reload(utils)
 except:
-	print("SOMETHING AWFUL HAPPENED")
-	pass
+	print("PROBLEM RELOADING MODULE cam.utils AT "+__name__)
 
 
 def slicing2d(ob, height):  # April 2020 Alain Pelletier

--- a/scripts/addons/cam/slice.py
+++ b/scripts/addons/cam/slice.py
@@ -23,7 +23,13 @@
 # completely rewritten April 2021
 
 import bpy
+import importlib
 from cam import utils
+try:
+	importlib.reload(utils)
+except:
+	print("SOMETHING AWFUL HAPPENED")
+	pass
 
 
 def slicing2d(ob, height):  # April 2020 Alain Pelletier

--- a/scripts/addons/cam/strategy.py
+++ b/scripts/addons/cam/strategy.py
@@ -32,11 +32,11 @@ import importlib
 camModules=["chunk", "collision", "simple", "pattern", "utils", "bridges", "polygon_utils_cam", "image_utils"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 from cam.chunk import *
 from cam.collision import *
 from cam.simple import *

--- a/scripts/addons/cam/strategy.py
+++ b/scripts/addons/cam/strategy.py
@@ -27,19 +27,22 @@ import time
 import math
 from math import *
 from bpy_extras import object_utils
-from cam import chunk
+
+import importlib
+camModules=["chunk", "collision", "simple", "pattern", "utils", "bridges", "polygon_utils_cam", "image_utils"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
 from cam.chunk import *
-from cam import collision
 from cam.collision import *
-from cam import simple
 from cam.simple import *
-from cam import pattern
 from cam.pattern import *
-from cam import utils, bridges
 from cam.utils import *
-from cam import polygon_utils_cam
 from cam.polygon_utils_cam import *
-from cam import image_utils
 from cam.image_utils import *
 
 from shapely.geometry import polygon as spolygon

--- a/scripts/addons/cam/testing.py
+++ b/scripts/addons/cam/testing.py
@@ -26,11 +26,11 @@ import importlib
 camModules=["simple", "utils"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 from cam.simple import *
 
 

--- a/scripts/addons/cam/testing.py
+++ b/scripts/addons/cam/testing.py
@@ -21,7 +21,16 @@
 
 import sys
 import bpy
-from cam import simple, utils
+
+import importlib
+camModules=["simple", "utils"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
 from cam.simple import *
 
 

--- a/scripts/addons/cam/ui.py
+++ b/scripts/addons/cam/ui.py
@@ -31,7 +31,15 @@ from bpy.props import (StringProperty,
 from bpy.types import (Panel, Menu, Operator, PropertyGroup, )
 
 
-from cam import gcodeimportparser
+import importlib
+camModules=["gcodeimportparser", "simple"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
 from cam.simple import *
 
 # EXPERIMENTAL=True#False

--- a/scripts/addons/cam/ui.py
+++ b/scripts/addons/cam/ui.py
@@ -35,11 +35,11 @@ import importlib
 camModules=["gcodeimportparser", "simple"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 from cam.simple import *
 
 # EXPERIMENTAL=True#False

--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -31,6 +31,16 @@ from bpy.props import *
 from bpy_extras import object_utils
 
 import sys, numpy,pickle
+
+import importlib
+camModules=["chunk", "collision", "simple", "pattern", "polygon_utils_cam", "image_utils", "opencamlib.opencamlib"]
+for mod in camModules:
+    try:
+        __import__("cam."+mod)
+        importlib.reload(mod)
+    except:
+	print("SOMETHING AWFUL HAPPENED")
+        pass
 from cam.chunk import *
 from cam.collision import *
 from cam.simple import *

--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -36,11 +36,11 @@ import importlib
 camModules=["chunk", "collision", "simple", "pattern", "polygon_utils_cam", "image_utils", "opencamlib.opencamlib"]
 for mod in camModules:
     try:
-        __import__("cam."+mod)
-        importlib.reload(mod)
+        modName=mod.split(".")[-1]
+        exec(modName + "=importlib.import_module('cam."+ mod+"')")
+        exec("importlib.reload("+modName+")")
     except:
-	print("SOMETHING AWFUL HAPPENED")
-        pass
+        print("PROBLEM (RE)LOADING MODULE cam."+mod+" AT "+__name__)
 from cam.chunk import *
 from cam.collision import *
 from cam.simple import *


### PR DESCRIPTION
Modified headers to enable reloading of modules by making use of importlib. This is supposed to make the add-on actually reload all modules in (the root of) "cam" directory when "Blender->System->Reload Scripts" is clicked. In this way, changes to any of those modules should be apparent immediately after clicking on the former without the need of restarting Blender and losing temporary variables.