### PR TITLE
auto install dependencies

### DIFF
--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -31,6 +31,14 @@ import subprocess
 import sys
 import threading
 import time
+
+try:
+    import shapely
+except ImportError:
+    # pip install required python stuff
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "shapely","equation","opencamlib"])
+
+
 from bpy.app.handlers import persistent
 from bpy.props import *
 from bpy.types import Menu, Operator, UIList, AddonPreferences

--- a/scripts/addons/cam/nc/attach.py
+++ b/scripts/addons/cam/nc/attach.py
@@ -5,8 +5,11 @@
 #
 
 import recreator
-import ocl
-import ocl_funcs
+try:
+    import ocl
+    import ocl_funcs
+except ImportError:
+    import opencamlib as ocl
 import nc
 
 attached = False

--- a/scripts/addons/cam/opencamlib/oclSample.py
+++ b/scripts/addons/cam/opencamlib/oclSample.py
@@ -2,7 +2,10 @@ import os
 try:
     import ocl
 except ImportError:
-    pass
+    try:
+        import opencamlib as ocl
+    except ImportError:
+        pass
 import tempfile
 
 from io_mesh_stl import blender_utils

--- a/scripts/addons/cam/opencamlib/opencamlib.py
+++ b/scripts/addons/cam/opencamlib/opencamlib.py
@@ -4,7 +4,10 @@ import bpy
 try:
     import ocl
 except ImportError:
-    pass
+    try:
+        import opencamlib as ocl
+    except ImportError:
+        pass
 import os
 import tempfile
 from subprocess import call

--- a/scripts/addons/cam/ui_panels/buttons_panel.py
+++ b/scripts/addons/cam/ui_panels/buttons_panel.py
@@ -39,6 +39,10 @@ class CAMButtonsPanel:
     def opencamlib_version(self):
         try:
             import ocl
-            return(ocl.version())
-        except ImportError as e:
-            return
+        except ImportError:
+            try:
+                import opencamlib as ocl
+            except ImportError as e:
+                return
+        return(ocl.version())
+


### PR DESCRIPTION
This pip installs dependencies on registration, which works now that opencamlib is on pypi

Also, opencamlib name has changed in the pip version. This makes it choose the right one depending on what you have installed.