### PR TITLE
Preserve length_unit in addMachineAreaObject

### DIFF
--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -1405,6 +1405,7 @@ def addMachineAreaObject():
         o = s.objects['CAM_machine']
     else:
         oldunits = s.unit_settings.system
+        oldLengthUnit = s.unit_settings.length_unit
         # need to be in metric units when adding machine mesh object
         # in order for location to work properly
         s.unit_settings.system = 'METRIC'
@@ -1431,6 +1432,7 @@ def addMachineAreaObject():
         o.hide_select = True
         # o.select = False
         s.unit_settings.system = oldunits
+        s.unit_settings.length_unit = oldLengthUnit
 
     # bpy.ops.wm.redraw_timer(type='DRAW_WIN_SWAP', iterations=1)
 


### PR DESCRIPTION
https://www.youtube.com/watch?v=uGqVS176tXs
Notice at the 3:26 mark, the guy clicks into the CAM Machine work area for X dimension. As soon as he does that, the code checks for the existence of a CAM_machine object, and if it doesn't exist, it creates one. That results in units switching from MILLIMETERS to METERS. Just like for unit system, we need to preserve the unit length.