### PR TITLE
interlock on calculate path maxz > freemovement

### DIFF
--- a/scripts/addons/cam/ops.py
+++ b/scripts/addons/cam/ops.py
@@ -179,6 +179,11 @@ class CalculatePath(bpy.types.Operator):
             self.report({'ERROR_INVALID_INPUT'}, "Operation can't be performed, see warnings for info")
             print("Operation can't be performed, see warnings for info")
             return {'CANCELLED'}
+        
+        #check for free movement height < maxz and return with error
+        if(o.movement.free_height < o.maxz):
+            self.report({'ERROR_INVALID_INPUT'}, "Free movement height is less than maximum Z height, correct and try again.")
+            return {'CANCELLED'}
 
         if o.computing:
             return {'FINISHED'}


### PR DESCRIPTION
added simple check for free_height < maxz and cancel the operation with a message if the condition is met