### PR TITLE
Waterline fix

### DIFF
--- a/scripts/addons/cam/image_utils.py
+++ b/scripts/addons/cam/image_utils.py
@@ -1078,6 +1078,7 @@ def renderSampleImage(o):
             n.links.new(n1.outputs['Depth'], n3.inputs['Image'])
             n.nodes.active = n2
             ###################
+            s.view_layers[n1.layer].use_pass_z=True
 
             r = s.render
             r.resolution_x = resx


### PR DESCRIPTION
By default z pass is disabled in eevee rendering. This means that waterline (non-opencamlib) doesn't work. This enables the pass.