### PR TITLE
waterline bugfixes

### DIFF
--- a/scripts/addons/cam/gcodepath.py
+++ b/scripts/addons/cam/gcodepath.py
@@ -719,7 +719,7 @@ def getPath3axis(context, operation):
         layerend = o.min.z  #
         layers = [[layerstart, layerend]]
         #######################
-        nslices = ceil(abs(o.minz / o.slice_detail))
+        nslices = ceil(abs((o.minz-o.maxz) / o.slice_detail))
         lastslice = spolygon.Polygon()  # polyversion
         layerstepinc = 0
 

--- a/scripts/addons/cam/image_utils.py
+++ b/scripts/addons/cam/image_utils.py
@@ -1060,6 +1060,9 @@ def renderSampleImage(o):
         if not o.update_zbufferimage_tag:
             try:
                 i = bpy.data.images.load(iname)
+                if i.size[0] != resx or i.size[1] != resy:
+                    print("Z buffer size changed:",i.size,resx,resy)
+                    o.update_zbufferimage_tag = True
             except:
                 o.update_zbufferimage_tag = True
         if o.update_zbufferimage_tag:


### PR DESCRIPTION
1) Make waterline work from z-start other than zero 
2) Make waterline re-render depth cache if objects are resized / moved, accuracy is changed, space around model altered etc.