### PR TITLE
Add warnings for when you (I) do silly things

### DIFF
--- a/scripts/addons/cam/chunk.py
+++ b/scripts/addons/cam/chunk.py
@@ -25,6 +25,7 @@ from shapely.geometry import polygon as spolygon
 from shapely import geometry as sgeometry
 from cam import polygon_utils_cam
 from cam.simple import *
+from cam.exception import CamException
 import math
 
 
@@ -970,7 +971,6 @@ def restoreVisibility(o, storage):
 
 
 def meshFromCurve(o, use_modifiers=False):
-    # print(o.name,o)
     activate(o)
     bpy.ops.object.duplicate()
 
@@ -980,6 +980,9 @@ def meshFromCurve(o, use_modifiers=False):
 
     if co.type == 'FONT':  # support for text objects is only and only here, just convert them to curves.
         bpy.ops.object.convert(target='CURVE', keep_original=False)
+    elif co.type != 'CURVE': # curve must be a curve...
+        bpy.ops.object.delete() # delete temporary object
+        raise CamException("Source curve object must be of type CURVE")
     co.data.dimensions = '3D'
     co.data.bevel_depth = 0
     co.data.extrude = 0

--- a/scripts/addons/cam/strategy.py
+++ b/scripts/addons/cam/strategy.py
@@ -209,7 +209,7 @@ async def curve(o):
     pathSamples = []
     utils.getOperationSources(o)
     if not o.onlycurves:
-        o.info.warnings += 'at least one of assigned objects is not a curve\n'
+        raise CamException("All objects must be curves for this operation.")
 
     for ob in o.objects:
         pathSamples.extend(curveToChunks(ob))  # make the chunks from curve here
@@ -257,8 +257,7 @@ async def proj_curve(s, o):
 
     from cam import chunk
     if targetCurve.type != 'CURVE':
-        o.info.warnings += 'Projection target and source have to be curve objects!\n '
-        return
+        raise CamException('Projection target and source have to be curve objects!')
 
     if 1:
         extend_up = 0.1
@@ -610,8 +609,7 @@ async def medial_axis(o):
     elif o.cutter_type == 'BALLNOSE':
         maxdepth = - new_cutter_diameter / 2 - o.skin
     else:
-        o.info.warnings += 'Only Ballnose, V-carve cutters\n are supported'
-        return
+        raise CamException("Only Ballnose and V-carve cutters are supported for meial axis.")
     # remember resolutions of curves, to refine them,
     # otherwise medial axis computation yields too many branches in curved parts
     resolutions_before = []
@@ -771,6 +769,10 @@ def getLayers(operation, startdepth, enddepth):
     """returns a list of layers bounded by startdepth and enddepth
        uses operation.stepdown to determine number of layers.
     """
+    if startdepth < enddepth:
+        raise CamException("Start depth is lower than end depth. "
+        "If you have set a custom depth end, it must be lower than depth start, "
+        "and should usually be negative. Set this in the CAM Operation Area panel.")
     if operation.use_layers:
         layers = []
         n = math.ceil((startdepth - enddepth) / operation.stepdown)

--- a/scripts/addons/cam/ui_panels/chains.py
+++ b/scripts/addons/cam/ui_panels/chains.py
@@ -3,6 +3,8 @@ import bpy
 from bpy.types import UIList
 from cam.ui_panels.buttons_panel import CAMButtonsPanel
 
+import cam
+
 
 class CAM_UL_operations(UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
@@ -37,6 +39,7 @@ class CAM_CHAINS_Panel(CAMButtonsPanel, bpy.types.Panel):
     bl_label = "CAM chains"
     bl_idname = "WORLD_PT_CAM_CHAINS"
     panel_interface_level = 1
+    always_show_panel = True
 
     def draw(self, context):
         layout = self.layout
@@ -63,13 +66,14 @@ class CAM_CHAINS_Panel(CAMButtonsPanel, bpy.types.Panel):
                     col.operator("scene.cam_chain_operation_down", icon='TRIA_DOWN', text="")
 
                 if not chain.computing:
-                    if chain.valid:
-                        pass
-                        layout.operator("object.calculate_cam_paths_chain", text="Calculate chain paths & Export Gcode")
-                        layout.operator("object.cam_export_paths_chain", text="Export chain gcode")
-                        layout.operator("object.cam_simulate_chain", text="Simulate this chain")
-                    else:
-                        layout.label(text="chain invalid, can't compute")
+                    layout.operator("object.calculate_cam_paths_chain", text="Calculate chain paths & Export Gcode")
+                    layout.operator("object.cam_export_paths_chain", text="Export chain gcode")
+                    layout.operator("object.cam_simulate_chain", text="Simulate this chain")
+
+                    valid,reason=cam.isChainValid(chain,context)
+                    if not valid:
+                        layout.label(icon="ERROR",text=f"Can't compute chain - reason:\n")
+                        layout.label(text=reason)
                 else:
                     layout.label(text='chain is currently computing')
 

--- a/scripts/addons/cam/ui_panels/info.py
+++ b/scripts/addons/cam/ui_panels/info.py
@@ -32,6 +32,7 @@ class CAM_INFO_Panel(CAMButtonsPanel, bpy.types.Panel):
     bl_label = "CAM info & warnings"
     bl_idname = "WORLD_PT_CAM_INFO"
     panel_interface_level = 0
+    always_show_panel = True
 
     prop_level = {
         'draw_blendercam_version': 0,
@@ -115,6 +116,7 @@ class CAM_INFO_Panel(CAMButtonsPanel, bpy.types.Panel):
         self.context = context
         self.draw_blendercam_version()
         self.draw_opencamlib_version()
-        self.draw_op_warnings()
-        self.draw_op_time()
-        self.draw_op_money_cost()
+        if self.op:
+            self.draw_op_warnings()
+            self.draw_op_time()
+            self.draw_op_money_cost()

--- a/scripts/addons/cam/ui_panels/operations.py
+++ b/scripts/addons/cam/ui_panels/operations.py
@@ -60,10 +60,10 @@ class CAM_OPERATIONS_Panel(CAMButtonsPanel, bpy.types.Panel):
             self.layout.label(text='!ERROR! COLLISION!')
             self.layout.prop(self.op.movement, 'free_height')
 
-        if self.op.valid:
-            self.layout.operator("object.calculate_cam_path", text="Calculate path & export Gcode")
-        else:
-            self.layout.label(text="operation invalid, can't compute")
+        if not self.op.valid:
+            self.layout.label(text="Select a valid object to calculate the path.")
+        # will be disable if not valid            
+        self.layout.operator("object.calculate_cam_path", text="Calculate path & export Gcode")
 
     def draw_export_gcode(self):
         if not self.has_correct_level(): return

--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -338,6 +338,8 @@ def getBounds(o):
         o.max.z = o.source_image_offset.z
     s = bpy.context.scene
     m = s.cam_machine
+    # make sure this message only shows once and goes away once fixed
+    o.info.warnings.replace('Operation exceeds your machine limits\n','')
     if o.max.x - o.min.x > m.working_area.x or o.max.y - o.min.y > m.working_area.y \
             or o.max.z - o.min.z > m.working_area.z:
         o.info.warnings += 'Operation exceeds your machine limits\n'


### PR DESCRIPTION
A bunch of UI fixes to make it hopefully impossible to do various silly things I have done in the past, and/or to show warnings if settings are wrong.

If for example you set end depth to 10cm instead of -10cm, in the previous version it just silently fails. Not any more - now it shows a warning message in getLayers.

Several things that previously showed a warning in the info panel then failed now show errors properly, e.g. selecting object that isn't a curve for a curve sourced operation. 

It also doesn't let you run an operation that isn't valid (e.g. deleted source object).