### PR TITLE
Property format

### DIFF
--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -62,7 +62,7 @@ from cam.ui import *
 bl_info = {
     "name": "CAM - gcode generation tools",
     "author": "Vilem Novak & Contributors",
-    "version": (1, 0, 5),
+    "version": (1, 0, 6),
     "blender": (3, 6, 0),
     "location": "Properties > render",
     "description": "Generate machining paths for CNC",
@@ -136,44 +136,49 @@ class CamAddonPreferences(AddonPreferences):
         default=False,
     )
 
-    update_source: bpy.props.StringProperty(
+    update_source: StringProperty(
         name="Source of updates for the addon",
-        description="This can be either a github repo link in which case it will download the latest release on there, "
-        "or an api link like https://api.github.com/repos/<author>/blendercam/commits to get from a github repository",
+        description="This can be either a github repo link in which case "
+        "it will download the latest release on there, "
+        "or an api link like "
+        "https://api.github.com/repos/<author>/blendercam/commits"
+        " to get from a github repository",
         default="https://github.com/pppalain/blendercam",
     )
 
     last_update_check: IntProperty(
         name="Last update time",
-        default=0
+        default=0,
     )
 
     last_commit_hash: StringProperty(
         name="Hash of last commit from updater",
-        default=""
+        default="",
     )
 
     just_updated: BoolProperty(
         name="Set to true on update or initial install",
-        default=True
+        default=True,
     )
 
     new_version_available: StringProperty(
         name="Set to new version name if one is found",
-        default=""
+        default="",
     )
 
-    default_interface_level: bpy.props.EnumProperty(
+    default_interface_level: EnumProperty(
         name="Interface level in new file",
         description="Choose visible options",
-        items=[('0', "Basic", "Only show essential options"),
-               ('1', "Advanced", "Show advanced options"),
-               ('2', "Complete", "Show all options"),
-               ('3', "Experimental", "Show experimental options")],
+        items=[
+            ('0', "Basic", "Only show essential options"),
+            ('1', "Advanced", "Show advanced options"),
+            ('2', "Complete", "Show all options"),
+            ('3', "Experimental", "Show experimental options")
+        ],
         default='3',
     )
 
-    default_machine_preset: bpy.props.StringProperty(
+    default_machine_preset: StringProperty(
         name="Machine preset in new file",
         description="So that machine preset choice persists between files",
         default='',
@@ -181,7 +186,8 @@ class CamAddonPreferences(AddonPreferences):
 
     def draw(self, context):
         layout = self.layout
-        layout.label(text="Use experimental features when you want to help development of Blender CAM:")
+        layout.label(
+            text="Use experimental features when you want to help development of Blender CAM:")
         layout.prop(self, "experimental")
         layout.prop(self, "update_source")
         layout.label(text="Choose a preset update source")
@@ -205,74 +211,161 @@ class CamAddonPreferences(AddonPreferences):
 
 class machineSettings(bpy.types.PropertyGroup):
     """stores all data for machines"""
-    # name = bpy.props.StringProperty(name="Machine Name", default="Machine")
-    post_processor: EnumProperty(name='Post processor',
-                                 items=(('ISO', 'Iso', 'exports standardized gcode ISO 6983 (RS-274)'),
-                                        ('MACH3', 'Mach3', 'default mach3'),
-                                        ('EMC', 'LinuxCNC - EMC2',
-                                         'Linux based CNC control software - formally EMC2'),
-                                        ('FADAL', 'Fadal', 'Fadal VMC'),
-                                        ('GRBL', 'grbl',
-                                         'optimized gcode for grbl firmware on Arduino with cnc shield'),
-                                        ('HEIDENHAIN', 'Heidenhain', 'heidenhain'),
-                                        ('HEIDENHAIN530', 'Heidenhain530', 'heidenhain530'),
-                                        ('TNC151', 'Heidenhain TNC151',
-                                         'Post Processor for the Heidenhain TNC151 machine'),
-                                        ('SIEGKX1', 'Sieg KX1', 'Sieg KX1'),
-                                        ('HM50', 'Hafco HM-50', 'Hafco HM-50'),
-                                        ('CENTROID', 'Centroid M40', 'Centroid M40'),
-                                        ('ANILAM', 'Anilam Crusader M', 'Anilam Crusader M'),
-                                        ('GRAVOS', 'Gravos', 'Gravos'),
-                                        ('WIN-PC', 'WinPC-NC', 'German CNC by Burkhard Lewetz'),
-                                        ('SHOPBOT MTC', 'ShopBot MTC', 'ShopBot MTC'),
-                                        ('LYNX_OTTER_O', 'Lynx Otter o', 'Lynx Otter o')),
-                                 description='Post processor',
-                                 default='MACH3')
+    # name = StringProperty(name="Machine Name", default="Machine")
+    post_processor: EnumProperty(
+        name='Post processor',
+        items=(
+            ('ISO', 'Iso', 'exports standardized gcode ISO 6983 (RS-274)'),
+            ('MACH3', 'Mach3', 'default mach3'),
+            ('EMC', 'LinuxCNC - EMC2',
+             'Linux based CNC control software - formally EMC2'),
+            ('FADAL', 'Fadal', 'Fadal VMC'),
+            ('GRBL', 'grbl',
+             'optimized gcode for grbl firmware on Arduino with cnc shield'),
+            ('HEIDENHAIN', 'Heidenhain', 'heidenhain'),
+            ('HEIDENHAIN530', 'Heidenhain530', 'heidenhain530'),
+            ('TNC151', 'Heidenhain TNC151',
+             'Post Processor for the Heidenhain TNC151 machine'),
+            ('SIEGKX1', 'Sieg KX1', 'Sieg KX1'),
+            ('HM50', 'Hafco HM-50', 'Hafco HM-50'),
+            ('CENTROID', 'Centroid M40', 'Centroid M40'),
+            ('ANILAM', 'Anilam Crusader M', 'Anilam Crusader M'),
+            ('GRAVOS', 'Gravos', 'Gravos'),
+            ('WIN-PC', 'WinPC-NC', 'German CNC by Burkhard Lewetz'),
+            ('SHOPBOT MTC', 'ShopBot MTC', 'ShopBot MTC'),
+            ('LYNX_OTTER_O', 'Lynx Otter o', 'Lynx Otter o')
+        ),
+        description='Post processor',
+        default='MACH3',
+    )
     # units = EnumProperty(name='Units', items = (('IMPERIAL', ''))
     # position definitions:
-    use_position_definitions: bpy.props.BoolProperty(name="Use position definitions",
-                                                     description="Define own positions for op start, "
-                                                                 "toolchange, ending position",
-                                                     default=False)
-    starting_position: bpy.props.FloatVectorProperty(name='Start position', default=(0, 0, 0), unit='LENGTH',
-                                                     precision=cam.constants.PRECISION, subtype="XYZ", update=updateMachine)
-    mtc_position: bpy.props.FloatVectorProperty(name='MTC position', default=(0, 0, 0), unit='LENGTH',
-                                                precision=cam.constants.PRECISION, subtype="XYZ", update=updateMachine)
-    ending_position: bpy.props.FloatVectorProperty(name='End position', default=(0, 0, 0), unit='LENGTH',
-                                                   precision=cam.constants.PRECISION, subtype="XYZ", update=updateMachine)
+    use_position_definitions: BoolProperty(
+        name="Use position definitions",
+        description="Define own positions for op start, "
+        "toolchange, ending position",
+        default=False,
+    )
+    starting_position: FloatVectorProperty(
+        name='Start position',
+        default=(0, 0, 0),
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        subtype="XYZ",
+        update=updateMachine,
+    )
+    mtc_position: FloatVectorProperty(
+        name='MTC position',
+        default=(0, 0, 0),
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        subtype="XYZ",
+        update=updateMachine,
+    )
+    ending_position: FloatVectorProperty(
+        name='End position',
+        default=(0, 0, 0),
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        subtype="XYZ",
+        update=updateMachine,
+    )
 
-    working_area: bpy.props.FloatVectorProperty(name='Work Area', default=(0.500, 0.500, 0.100), unit='LENGTH',
-                                                precision=cam.constants.PRECISION, subtype="XYZ", update=updateMachine)
-    feedrate_min: bpy.props.FloatProperty(name="Feedrate minimum /min", default=0.0, min=0.00001, max=320000,
-                                          precision=cam.constants.PRECISION, unit='LENGTH')
-    feedrate_max: bpy.props.FloatProperty(name="Feedrate maximum /min", default=2, min=0.00001, max=320000,
-                                          precision=cam.constants.PRECISION, unit='LENGTH')
-    feedrate_default: bpy.props.FloatProperty(name="Feedrate default /min", default=1.5, min=0.00001, max=320000,
-                                              precision=cam.constants.PRECISION, unit='LENGTH')
-    hourly_rate: bpy.props.FloatProperty(name="Price per hour", default=100, min=0.005, precision=2)
+    working_area: FloatVectorProperty(
+        name='Work Area',
+        default=(0.500, 0.500, 0.100),
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        subtype="XYZ",
+        update=updateMachine,
+    )
+    feedrate_min: FloatProperty(
+        name="Feedrate minimum /min",
+        default=0.0,
+        min=0.00001,
+        max=320000,
+        precision=cam.constants.PRECISION,
+        unit='LENGTH',
+    )
+    feedrate_max: FloatProperty(
+        name="Feedrate maximum /min",
+        default=2,
+        min=0.00001,
+        max=320000,
+        precision=cam.constants.PRECISION,
+        unit='LENGTH',
+    )
+    feedrate_default: FloatProperty(
+        name="Feedrate default /min",
+        default=1.5,
+        min=0.00001,
+        max=320000,
+        precision=cam.constants.PRECISION,
+        unit='LENGTH',
+    )
+    hourly_rate: FloatProperty(
+        name="Price per hour",
+        default=100,
+        min=0.005,
+        precision=2,
+    )
 
     # UNSUPPORTED:
 
-    spindle_min: bpy.props.FloatProperty(name="Spindle speed minimum RPM", default=5000, min=0.00001, max=320000,
-                                         precision=1)
-    spindle_max: bpy.props.FloatProperty(name="Spindle speed maximum RPM", default=30000, min=0.00001, max=320000,
-                                         precision=1)
-    spindle_default: bpy.props.FloatProperty(name="Spindle speed default RPM", default=15000, min=0.00001, max=320000,
-                                             precision=1)
-    spindle_start_time: bpy.props.FloatProperty(name="Spindle start delay seconds",
-                                                description='Wait for the spindle to start spinning before starting '
-                                                            'the feeds , in seconds',
-                                                default=0, min=0.0000, max=320000, precision=1)
+    spindle_min: FloatProperty(
+        name="Spindle speed minimum RPM",
+        default=5000,
+        min=0.00001,
+        max=320000,
+        precision=1,
+    )
+    spindle_max: FloatProperty(
+        name="Spindle speed maximum RPM",
+        default=30000,
+        min=0.00001,
+        max=320000,
+        precision=1,
+    )
+    spindle_default: FloatProperty(
+        name="Spindle speed default RPM",
+        default=15000,
+        min=0.00001,
+        max=320000,
+        precision=1,
+    )
+    spindle_start_time: FloatProperty(
+        name="Spindle start delay seconds",
+        description='Wait for the spindle to start spinning before starting '
+        'the feeds , in seconds',
+        default=0,
+        min=0.0000,
+        max=320000,
+        precision=1,
+    )
 
-    axis4: bpy.props.BoolProperty(name="#4th axis", description="Machine has 4th axis", default=0)
-    axis5: bpy.props.BoolProperty(name="#5th axis", description="Machine has 5th axis", default=0)
+    axis4: BoolProperty(
+        name="#4th axis",
+        description="Machine has 4th axis",
+        default=0,
+    )
+    axis5: BoolProperty(
+        name="#5th axis",
+        description="Machine has 5th axis",
+        default=0,
+    )
 
-    eval_splitting: bpy.props.BoolProperty(name="Split files",
-                                           description="split gcode file with large number of operations",
-                                           default=True)  # split large files
-    split_limit: IntProperty(name="Operations per file",
-                             description="Split files with larger number of operations than this", min=1000,
-                             max=20000000, default=800000)
+    eval_splitting: BoolProperty(
+        name="Split files",
+        description="split gcode file with large number of operations",
+        default=True,
+    )  # split large files
+    split_limit: IntProperty(
+        name="Operations per file",
+        description="Split files with larger number of operations than this",
+        min=1000,
+        max=20000000,
+        default=800000,
+    )
 
     # rotary_axis1 = EnumProperty(name='Axis 1',
     #     items=(
@@ -282,80 +375,179 @@ class machineSettings(bpy.types.PropertyGroup):
     #     description='Number 1 rotational axis',
     #     default='X', update = updateOffsetImage)
 
-    collet_size: bpy.props.FloatProperty(name="#Collet size", description="Collet size for collision detection",
-                                         default=33, min=0.00001, max=320000, precision=cam.constants.PRECISION, unit="LENGTH")
-    # exporter_start = bpy.props.StringProperty(name="exporter start", default="%")
+    collet_size: FloatProperty(
+        name="#Collet size",
+        description="Collet size for collision detection",
+        default=33,
+        min=0.00001,
+        max=320000,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+    )
+    # exporter_start = StringProperty(name="exporter start", default="%")
 
     # post processor options
 
-    output_block_numbers: BoolProperty(name="output block numbers",
-                                       description="output block numbers ie N10 at start of line", default=False)
+    output_block_numbers: BoolProperty(
+        name="output block numbers",
+        description="output block numbers ie N10 at start of line",
+        default=False,
+    )
 
-    start_block_number: IntProperty(name="start block number", description="the starting block number ie 10",
-                                    default=10)
+    start_block_number: IntProperty(
+        name="start block number",
+        description="the starting block number ie 10",
+        default=10,
+    )
 
-    block_number_increment: IntProperty(name="block number increment",
-                                        description="how much the block number should increment for the next line",
-                                        default=10)
+    block_number_increment: IntProperty(
+        name="block number increment",
+        description="how much the block number should "
+        "increment for the next line",
+        default=10,
+    )
 
-    output_tool_definitions: BoolProperty(name="output tool definitions", description="output tool definitions",
-                                          default=True)
+    output_tool_definitions: BoolProperty(
+        name="output tool definitions",
+        description="output tool definitions",
+        default=True,
+    )
 
-    output_tool_change: BoolProperty(name="output tool change commands",
-                                     description="output tool change commands ie: Tn M06", default=True)
+    output_tool_change: BoolProperty(
+        name="output tool change commands",
+        description="output tool change commands ie: Tn M06",
+        default=True,
+    )
 
-    output_g43_on_tool_change: BoolProperty(name="output G43 on tool change",
-                                            description="output G43 on tool change line", default=False)
+    output_g43_on_tool_change: BoolProperty(
+        name="output G43 on tool change",
+        description="output G43 on tool change line",
+        default=False,
+    )
 
 
 class PackObjectsSettings(bpy.types.PropertyGroup):
     """stores all data for machines"""
-    sheet_fill_direction: EnumProperty(name='Fill direction',
-                                       items=(('X', 'X', 'Fills sheet in X axis direction'),
-                                              ('Y', 'Y', 'Fills sheet in Y axis direction')),
-                                       description='Fill direction of the packer algorithm',
-                                       default='Y')
-    sheet_x: FloatProperty(name="X size", description="Sheet size", min=0.001, max=10, default=0.5,
-                           precision=cam.constants.PRECISION, unit="LENGTH")
-    sheet_y: FloatProperty(name="Y size", description="Sheet size", min=0.001, max=10, default=0.5,
-                           precision=cam.constants.PRECISION, unit="LENGTH")
-    distance: FloatProperty(name="Minimum distance",
-                            description="minimum distance between objects(should be at least cutter diameter!)",
-                            min=0.001, max=10, default=0.01, precision=cam.constants.PRECISION, unit="LENGTH")
-    tolerance: FloatProperty(name="Placement Tolerance",
-                             description="Tolerance for placement: smaller value slower placemant",
-                             min=0.001, max=0.02, default=0.005, precision=cam.constants.PRECISION, unit="LENGTH")
-    rotate: bpy.props.BoolProperty(
-        name="enable rotation", description="Enable rotation of elements", default=True)
-    rotate_angle: FloatProperty(name="Placement Angle rotation step",
-                                description="bigger rotation angle,faster placemant", default=0.19635 * 4,
-                                min=math.pi/180,
-                                max=math.pi, precision=5,
-                                subtype="ANGLE", unit="ROTATION")
+    sheet_fill_direction: EnumProperty(
+        name='Fill direction',
+        items=(
+            ('X', 'X', 'Fills sheet in X axis direction'),
+            ('Y', 'Y', 'Fills sheet in Y axis direction')
+        ),
+        description='Fill direction of the packer algorithm',
+        default='Y',
+    )
+    sheet_x: FloatProperty(
+        name="X size",
+        description="Sheet size",
+        min=0.001,
+        max=10,
+        default=0.5,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+    )
+    sheet_y: FloatProperty(
+        name="Y size",
+        description="Sheet size",
+        min=0.001,
+        max=10,
+        default=0.5,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+    )
+    distance: FloatProperty(
+        name="Minimum distance",
+        description="minimum distance between objects(should be "
+        "at least cutter diameter!)",
+        min=0.001,
+        max=10,
+        default=0.01,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+    )
+    tolerance: FloatProperty(
+        name="Placement Tolerance",
+        description="Tolerance for placement: smaller value slower placemant",
+        min=0.001,
+        max=0.02,
+        default=0.005,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+    )
+    rotate: BoolProperty(
+        name="enable rotation",
+        description="Enable rotation of elements",
+        default=True,
+    )
+    rotate_angle: FloatProperty(
+        name="Placement Angle rotation step",
+        description="bigger rotation angle,faster placemant",
+        default=0.19635 * 4,
+        min=math.pi/180,
+        max=math.pi,
+        precision=5,
+        subtype="ANGLE",
+        unit="ROTATION",
+    )
 
 
 class SliceObjectsSettings(bpy.types.PropertyGroup):
     """stores all data for machines"""
-    slice_distance: FloatProperty(name="Slicing distance",
-                                  description="slices distance in z, should be most often thickness of plywood sheet.",
-                                  min=0.001, max=10, default=0.005, precision=cam.constants.PRECISION, unit="LENGTH")
-    slice_above0: bpy.props.BoolProperty(
-        name="Slice above 0", description="only slice model above 0", default=False)
-    slice_3d: bpy.props.BoolProperty(name="3d slice", description="for 3d carving", default=False)
-    indexes: bpy.props.BoolProperty(
-        name="add indexes", description="adds index text of layer + index", default=True)
+    slice_distance: FloatProperty(
+        name="Slicing distance",
+        description="slices distance in z, should be most often "
+        "thickness of plywood sheet.",
+        min=0.001,
+        max=10,
+        default=0.005,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+    )
+    slice_above0: BoolProperty(
+        name="Slice above 0",
+        description="only slice model above 0",
+        default=False,
+    )
+    slice_3d: BoolProperty(
+        name="3d slice",
+        description="for 3d carving",
+        default=False,
+    )
+    indexes: BoolProperty(
+        name="add indexes",
+        description="adds index text of layer + index",
+        default=True,
+    )
 
 
 class import_settings(bpy.types.PropertyGroup):
-    split_layers: BoolProperty(name="Split Layers", description="Save every layer as single Objects in Collection",
-                               default=False)
-    subdivide: BoolProperty(name="Subdivide",
-                            description="Only Subdivide gcode segments that are bigger than 'Segment length' ",
-                            default=False)
-    output: bpy.props.EnumProperty(name="output type", items=(
-        ('mesh', 'Mesh', 'Make a mesh output'), ('curve', 'Curve', 'Make curve output')), default='curve')
-    max_segment_size: FloatProperty(name="", description="Only Segments bigger then this value get subdivided",
-                                    default=0.001, min=0.0001, max=1.0, unit="LENGTH")
+    split_layers: BoolProperty(
+        name="Split Layers",
+        description="Save every layer as single Objects in Collection",
+        default=False,
+    )
+    subdivide: BoolProperty(
+        name="Subdivide",
+        description="Only Subdivide gcode segments that are "
+        "bigger than 'Segment length' ",
+        default=False,
+    )
+    output: EnumProperty(
+        name="output type",
+        items=(
+            ('mesh', 'Mesh', 'Make a mesh output'),
+            ('curve', 'Curve', 'Make curve output')
+        ),
+        default='curve',
+    )
+    max_segment_size: FloatProperty(
+        name="",
+        description="Only Segments bigger then this value get subdivided",
+        default=0.001,
+        min=0.0001,
+        max=1.0,
+        unit="LENGTH",
+    )
 
 
 def isValid(o, context):
@@ -546,7 +738,8 @@ def getStrategyList(scene, context):
         ('OUTLINEFILL', 'Outline Fill',
          'Detect outline and fill it with paths as pocket. Then sample these paths on the 3d surface'),
         ('CARVE', 'Project curve to surface', 'Engrave the curve path to surface'),
-        ('WATERLINE', 'Waterline - Roughing -below zero', 'Waterline paths - constant z below zero'),
+        ('WATERLINE', 'Waterline - Roughing -below zero',
+         'Waterline paths - constant z below zero'),
         ('CURVE', 'Curve to Path', 'Curve object gets converted directly to path'),
         ('MEDIAL_AXIS', 'Medial axis',
          'Medial axis, must be used with V or ball cutter, for engraving various width shapes with a single stroke ')
@@ -562,411 +755,954 @@ def getStrategyList(scene, context):
 
 class camOperation(bpy.types.PropertyGroup):
 
-    material: bpy.props.PointerProperty(type=CAM_MATERIAL_Properties)
-    info: bpy.props.PointerProperty(type=CAM_INFO_Properties)
-    optimisation: bpy.props.PointerProperty(type=CAM_OPTIMISATION_Properties)
-    movement: bpy.props.PointerProperty(type=CAM_MOVEMENT_Properties)
+    material: PointerProperty(
+        type=CAM_MATERIAL_Properties
+    )
+    info: PointerProperty(
+        type=CAM_INFO_Properties
+    )
+    optimisation: PointerProperty(
+        type=CAM_OPTIMISATION_Properties
+    )
+    movement: PointerProperty(
+        type=CAM_MOVEMENT_Properties
+    )
 
-    name: bpy.props.StringProperty(name="Operation Name", default="Operation", update=updateRest)
-    filename: bpy.props.StringProperty(name="File name", default="Operation", update=updateRest)
-    auto_export: bpy.props.BoolProperty(name="Auto export",
-                                        description="export files immediately after path calculation", default=True)
-    remove_redundant_points: bpy.props.BoolProperty(
+    name: StringProperty(
+        name="Operation Name",
+        default="Operation",
+        update=updateRest,
+    )
+    filename: StringProperty(
+        name="File name",
+        default="Operation",
+        update=updateRest,
+    )
+    auto_export: BoolProperty(
+        name="Auto export",
+        description="export files immediately after path calculation",
+        default=True,
+    )
+    remove_redundant_points: BoolProperty(
         name="Symplify Gcode",
         description="Remove redundant points sharing the same angle"
                     " as the start vector",
-        default=False)
-    simplify_tol: bpy.props.IntProperty(name="Tolerance", description='lower number means more precise', default=50,
-                                        min=1, max=1000)
-    hide_all_others: bpy.props.BoolProperty(
+        default=False,
+    )
+    simplify_tol: IntProperty(
+        name="Tolerance",
+        description='lower number means more precise',
+        default=50,
+        min=1,
+        max=1000,
+    )
+    hide_all_others: BoolProperty(
         name="Hide all others",
         description="Hide all other tool pathes except toolpath"
                     " assotiated with selected CAM operation",
-        default=False)
-    parent_path_to_object: bpy.props.BoolProperty(
+        default=False,
+    )
+    parent_path_to_object: BoolProperty(
         name="Parent path to object",
         description="Parent generated CAM path to source object",
-        default=False)
-    object_name: bpy.props.StringProperty(name='Object', description='object handled by this operation',
-                                          update=updateOperationValid)
-    collection_name: bpy.props.StringProperty(name='Collection',
-                                              description='Object collection handled by this operation',
-                                              update=updateOperationValid)
-    curve_object: bpy.props.StringProperty(name='Curve source',
-                                           description='curve which will be sampled along the 3d object',
-                                           update=operationValid)
-    curve_object1: bpy.props.StringProperty(name='Curve target',
-                                            description='curve which will serve as attractor for the cutter when the cutter follows the curve',
-                                            update=operationValid)
-    source_image_name: bpy.props.StringProperty(
-        name='image_source', description='image source', update=operationValid)
-    geometry_source: EnumProperty(name='Source of data',
-                                  items=(
-                                      ('OBJECT', 'object', 'a'), ('COLLECTION',
-                                                                  'Collection of objects', 'a'),
-                                      ('IMAGE', 'Image', 'a')),
-                                  description='Geometry source',
-                                  default='OBJECT', update=updateOperationValid)
-    cutter_type: EnumProperty(name='Cutter',
-                              items=(
-                                  ('END', 'End', 'end - flat cutter'),
-                                  ('BALLNOSE', 'Ballnose', 'ballnose cutter'),
-                                  ('BULLNOSE', 'Bullnose', 'bullnose cutter ***placeholder **'),
-                                  ('VCARVE', 'V-carve', 'v carve cutter'),
-                                  ('BALLCONE', 'Ballcone', 'Ball with a Cone for Parallel - X'),
-                                  ('CYLCONE', 'Cylinder cone', 'Cylinder end with a Cone for Parallel - X'),
-                                  ('LASER', 'Laser', 'Laser cutter'),
-                                  ('PLASMA', 'Plasma', 'Plasma cutter'),
-                                  ('CUSTOM', 'Custom-EXPERIMENTAL', 'modelled cutter - not well tested yet.')),
-                              description='Type of cutter used',
-                              default='END', update=updateZbufferImage)
-    cutter_object_name: bpy.props.StringProperty(name='Cutter object',
-                                                 description='object used as custom cutter for this operation',
-                                                 update=updateZbufferImage)
+        default=False,
+    )
+    object_name: StringProperty(
+        name='Object',
+        description='object handled by this operation',
+        update=updateOperationValid,
+    )
+    collection_name: StringProperty(
+        name='Collection',
+        description='Object collection handled by this operation',
+        update=updateOperationValid,
+    )
+    curve_object: StringProperty(
+        name='Curve source',
+        description='curve which will be sampled along the 3d object',
+        update=operationValid,
+    )
+    curve_object1: StringProperty(
+        name='Curve target',
+        description='curve which will serve as attractor for the '
+        'cutter when the cutter follows the curve',
+        update=operationValid,
+    )
+    source_image_name: StringProperty(
+        name='image_source',
+        description='image source',
+        update=operationValid,
+    )
+    geometry_source: EnumProperty(
+        name='Source of data',
+        items=(
+            ('OBJECT', 'object', 'a'),
+            ('COLLECTION', 'Collection of objects', 'a'),
+            ('IMAGE', 'Image', 'a')
+        ),
+        description='Geometry source',
+        default='OBJECT',
+        update=updateOperationValid,
+    )
+    cutter_type: EnumProperty(
+        name='Cutter',
+        items=(
+            ('END', 'End', 'end - flat cutter'),
+            ('BALLNOSE', 'Ballnose', 'ballnose cutter'),
+            ('BULLNOSE', 'Bullnose', 'bullnose cutter ***placeholder **'),
+            ('VCARVE', 'V-carve', 'v carve cutter'),
+            ('BALLCONE', 'Ballcone', 'Ball with a Cone for Parallel - X'),
+            ('CYLCONE', 'Cylinder cone',
+             'Cylinder end with a Cone for Parallel - X'),
+            ('LASER', 'Laser', 'Laser cutter'),
+            ('PLASMA', 'Plasma', 'Plasma cutter'),
+            ('CUSTOM', 'Custom-EXPERIMENTAL',
+             'modelled cutter - not well tested yet.')
+        ),
+        description='Type of cutter used',
+        default='END',
+        update=updateZbufferImage,
+    )
+    cutter_object_name: StringProperty(
+        name='Cutter object',
+        description='object used as custom cutter for this operation',
+        update=updateZbufferImage,
+    )
 
-    machine_axes: EnumProperty(name='Number of axes',
-                               items=(
-                                   ('3', '3 axis', 'a'),
-                                   ('4', '#4 axis - EXPERIMENTAL', 'a'),
-                                   ('5', '#5 axis - EXPERIMENTAL', 'a')),
-                               description='How many axes will be used for the operation',
-                               default='3', update=updateStrategy)
-    strategy: EnumProperty(name='Strategy',
-                           items=getStrategyList,
-                           description='Strategy',
-                           update=updateStrategy)
+    machine_axes: EnumProperty(
+        name='Number of axes',
+        items=(
+            ('3', '3 axis', 'a'),
+            ('4', '#4 axis - EXPERIMENTAL', 'a'),
+            ('5', '#5 axis - EXPERIMENTAL', 'a')
+        ),
+        description='How many axes will be used for the operation',
+        default='3',
+        update=updateStrategy,
+    )
+    strategy: EnumProperty(
+        name='Strategy',
+        items=getStrategyList,
+        description='Strategy',
+        update=updateStrategy,
+    )
 
-    strategy4axis: EnumProperty(name='4 axis Strategy',
-                                items=(
-                                    ('PARALLELR', 'Parallel around 1st rotary axis',
-                                     'Parallel lines around first rotary axis'),
-                                    ('PARALLEL', 'Parallel along 1st rotary axis',
-                                     'Parallel lines along first rotary axis'),
-                                    ('HELIX', 'Helix around 1st rotary axis', 'Helix around rotary axis'),
-                                    ('INDEXED', 'Indexed 3-axis',
-                                     'all 3 axis strategies, just applied to the 4th axis'),
-                                    ('CROSS', 'Cross', 'Cross paths')),
-                                description='#Strategy',
-                                default='PARALLEL',
-                                update=updateStrategy)
-    strategy5axis: EnumProperty(name='Strategy',
-                                items=(
-                                    ('INDEXED', 'Indexed 3-axis',
-                                     'all 3 axis strategies, just rotated by 4+5th axes'),
-                                ),
-                                description='5 axis Strategy',
-                                default='INDEXED',
-                                update=updateStrategy)
+    strategy4axis: EnumProperty(
+        name='4 axis Strategy',
+        items=(
+            ('PARALLELR', 'Parallel around 1st rotary axis',
+             'Parallel lines around first rotary axis'),
+            ('PARALLEL', 'Parallel along 1st rotary axis',
+             'Parallel lines along first rotary axis'),
+            ('HELIX', 'Helix around 1st rotary axis',
+             'Helix around rotary axis'),
+            ('INDEXED', 'Indexed 3-axis',
+             'all 3 axis strategies, just applied to the 4th axis'),
+            ('CROSS', 'Cross', 'Cross paths')
+        ),
+        description='#Strategy',
+        default='PARALLEL',
+        update=updateStrategy,
+    )
+    strategy5axis: EnumProperty(
+        name='Strategy',
+        items=(
+            ('INDEXED', 'Indexed 3-axis',
+             'all 3 axis strategies, just rotated by 4+5th axes'),
+        ),
+        description='5 axis Strategy',
+        default='INDEXED',
+        update=updateStrategy,
+    )
 
-    rotary_axis_1: EnumProperty(name='Rotary axis',
-                                items=(
-                                    ('X', 'X', ''),
-                                    ('Y', 'Y', ''),
-                                    ('Z', 'Z', ''),
-                                ),
-                                description='Around which axis rotates the first rotary axis',
-                                default='X',
-                                update=updateStrategy)
-    rotary_axis_2: EnumProperty(name='Rotary axis 2',
-                                items=(
-                                    ('X', 'X', ''),
-                                    ('Y', 'Y', ''),
-                                    ('Z', 'Z', ''),
-                                ),
-                                description='Around which axis rotates the second rotary axis',
-                                default='Z',
-                                update=updateStrategy)
+    rotary_axis_1: EnumProperty(
+        name='Rotary axis',
+        items=(
+            ('X', 'X', ''),
+            ('Y', 'Y', ''),
+            ('Z', 'Z', ''),
+        ),
+        description='Around which axis rotates the first rotary axis',
+        default='X',
+        update=updateStrategy,
+    )
+    rotary_axis_2: EnumProperty(
+        name='Rotary axis 2',
+        items=(
+            ('X', 'X', ''),
+            ('Y', 'Y', ''),
+            ('Z', 'Z', ''),
+        ),
+        description='Around which axis rotates the second rotary axis',
+        default='Z',
+        update=updateStrategy,
+    )
 
-    skin: FloatProperty(name="Skin", description="Material to leave when roughing ", min=0.0, max=1.0, default=0.0,
-                        precision=cam.constants.PRECISION, unit="LENGTH", update=updateOffsetImage)
-    inverse: bpy.props.BoolProperty(name="Inverse milling", description="Male to female model conversion",
-                                    default=False, update=updateOffsetImage)
-    array: bpy.props.BoolProperty(name="Use array",
-                                  description="Create a repetitive array for producing the same thing manytimes",
-                                  default=False, update=updateRest)
-    array_x_count: bpy.props.IntProperty(name="X count", description="X count", default=1, min=1, max=32000,
-                                         update=updateRest)
-    array_y_count: bpy.props.IntProperty(name="Y count", description="Y count", default=1, min=1, max=32000,
-                                         update=updateRest)
-    array_x_distance: FloatProperty(name="X distance", description="distance between operation origins", min=0.00001,
-                                    max=1.0, default=0.01, precision=cam.constants.PRECISION, unit="LENGTH", update=updateRest)
-    array_y_distance: FloatProperty(name="Y distance", description="distance between operation origins", min=0.00001,
-                                    max=1.0, default=0.01, precision=cam.constants.PRECISION, unit="LENGTH", update=updateRest)
+    skin: FloatProperty(
+        name="Skin",
+        description="Material to leave when roughing ",
+        min=0.0,
+        max=1.0,
+        default=0.0,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateOffsetImage,
+    )
+    inverse: BoolProperty(
+        name="Inverse milling",
+        description="Male to female model conversion",
+        default=False,
+        update=updateOffsetImage,
+    )
+    array: BoolProperty(
+        name="Use array",
+        description="Create a repetitive array for producing the "
+        "same thing many times",
+        default=False,
+        update=updateRest,
+    )
+    array_x_count: IntProperty(
+        name="X count",
+        description="X count",
+        default=1,
+        min=1,
+        max=32000,
+        update=updateRest,
+    )
+    array_y_count: IntProperty(
+        name="Y count",
+        description="Y count",
+        default=1,
+        min=1,
+        max=32000,
+        update=updateRest,
+    )
+    array_x_distance: FloatProperty(
+        name="X distance",
+        description="distance between operation origins",
+        min=0.00001,
+        max=1.0,
+        default=0.01,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
+    array_y_distance: FloatProperty(
+        name="Y distance",
+        description="distance between operation origins",
+        min=0.00001,
+        max=1.0,
+        default=0.01,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
 
     # pocket options
-    pocket_option: EnumProperty(name='Start Position', items=(
-        ('INSIDE', 'Inside', 'a'), ('OUTSIDE', 'Outside', 'a')),
-        description='Pocket starting position', default='INSIDE', update=updateRest)
-    pocketToCurve: bpy.props.BoolProperty(name="Pocket to curve",
-                                          description="generates a curve instead of a path",
-                                          default=False, update=updateRest)
+    pocket_option: EnumProperty(
+        name='Start Position',
+        items=(
+            ('INSIDE', 'Inside', 'a'),
+            ('OUTSIDE', 'Outside', 'a')
+        ),
+        description='Pocket starting position',
+        default='INSIDE',
+        update=updateRest,
+    )
+    pocketToCurve: BoolProperty(
+        name="Pocket to curve",
+        description="generates a curve instead of a path",
+        default=False,
+        update=updateRest,
+    )
     # Cutout
-    cut_type: EnumProperty(name='Cut',
-                           items=(('OUTSIDE', 'Outside', 'a'), ('INSIDE',
-                                                                'Inside', 'a'), ('ONLINE', 'On line', 'a')),
-                           description='Type of cutter used', default='OUTSIDE', update=updateRest)
-    outlines_count: bpy.props.IntProperty(name="Outlines count", description="Outlines count", default=1,
-                                          min=1, max=32, update=updateCutout)
-    straight: bpy.props.BoolProperty(name="Overshoot Style",
-                                     description="Use overshoot cutout instead of conventional rounded",
-                                     default=False, update=updateRest)
+    cut_type: EnumProperty(
+        name='Cut',
+        items=(
+            ('OUTSIDE', 'Outside', 'a'),
+            ('INSIDE', 'Inside', 'a'),
+            ('ONLINE', 'On line', 'a')
+        ),
+        description='Type of cutter used',
+        default='OUTSIDE',
+        update=updateRest,
+    )
+    outlines_count: IntProperty(
+        name="Outlines count",
+        description="Outlines count",
+        default=1,
+        min=1,
+        max=32,
+        update=updateCutout,
+    )
+    straight: BoolProperty(
+        name="Overshoot Style",
+        description="Use overshoot cutout instead of conventional rounded",
+        default=False,
+        update=updateRest,
+    )
     # cutter
-    cutter_id: IntProperty(name="Tool number", description="For machines which support tool change based on tool id",
-                           min=0, max=10000, default=1, update=updateRest)
-    cutter_diameter: FloatProperty(name="Cutter diameter", description="Cutter diameter = 2x cutter radius",
-                                   min=0.000001, max=10, default=0.003, precision=cam.constants.PRECISION, unit="LENGTH",
-                                   update=updateOffsetImage)
-    cylcone_diameter: FloatProperty(name="Bottom Diameter", description="Bottom diameter",
-                                    min=0.000001, max=10, default=0.003, precision=cam.constants.PRECISION, unit="LENGTH",
-                                    update=updateOffsetImage)
-    cutter_length: FloatProperty(name="#Cutter length", description="#not supported#Cutter length", min=0.0, max=100.0,
-                                 default=25.0, precision=cam.constants.PRECISION, unit="LENGTH", update=updateOffsetImage)
-    cutter_flutes: IntProperty(name="Cutter flutes", description="Cutter flutes", min=1, max=20, default=2,
-                               update=updateChipload)
-    cutter_tip_angle: FloatProperty(name="Cutter v-carve angle", description="Cutter v-carve angle", min=0.0,
-                                    max=180.0, default=60.0, precision=cam.constants.PRECISION, update=updateOffsetImage)
-    ball_radius: FloatProperty(name="Ball radius", description="Radius of", min=0.0,
-                               max=0.035, default=0.001, unit="LENGTH", precision=cam.constants.PRECISION, update=updateOffsetImage)
+    cutter_id: IntProperty(
+        name="Tool number",
+        description="For machines which support tool change based on tool id",
+        min=0,
+        max=10000,
+        default=1,
+        update=updateRest,
+    )
+    cutter_diameter: FloatProperty(
+        name="Cutter diameter",
+        description="Cutter diameter = 2x cutter radius",
+        min=0.000001,
+        max=10,
+        default=0.003,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateOffsetImage,
+    )
+    cylcone_diameter: FloatProperty(
+        name="Bottom Diameter",
+        description="Bottom diameter",
+        min=0.000001,
+        max=10,
+        default=0.003,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateOffsetImage,
+    )
+    cutter_length: FloatProperty(
+        name="#Cutter length",
+        description="#not supported#Cutter length",
+        min=0.0,
+        max=100.0,
+        default=25.0,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateOffsetImage,
+    )
+    cutter_flutes: IntProperty(
+        name="Cutter flutes",
+        description="Cutter flutes",
+        min=1,
+        max=20,
+        default=2,
+        update=updateChipload,
+    )
+    cutter_tip_angle: FloatProperty(
+        name="Cutter v-carve angle",
+        description="Cutter v-carve angle",
+        min=0.0,
+        max=180.0,
+        default=60.0,
+        precision=cam.constants.PRECISION,
+        update=updateOffsetImage,
+    )
+    ball_radius: FloatProperty(
+        name="Ball radius",
+        description="Radius of",
+        min=0.0,
+        max=0.035,
+        default=0.001,
+        unit="LENGTH",
+        precision=cam.constants.PRECISION,
+        update=updateOffsetImage,
+    )
     # ball_cone_flute: FloatProperty(name="BallCone Flute Length", description="length of flute", min=0.0,
     #                                 max=0.1, default=0.017, unit="LENGTH", precision=cam.constants.PRECISION, update=updateOffsetImage)
-    bull_corner_radius: FloatProperty(name="Bull Corner Radius", description="Radius tool bit corner", min=0.0,
-                                      max=0.035, default=0.005, unit="LENGTH", precision=cam.constants.PRECISION,
-                                      update=updateOffsetImage)
+    bull_corner_radius: FloatProperty(
+        name="Bull Corner Radius",
+        description="Radius tool bit corner",
+        min=0.0,
+        max=0.035,
+        default=0.005,
+        unit="LENGTH",
+        precision=cam.constants.PRECISION,
+        update=updateOffsetImage,
+    )
 
     cutter_description: StringProperty(
-        name="Tool Description", default="", update=updateOffsetImage)
+        name="Tool Description",
+        default="",
+        update=updateOffsetImage,
+    )
 
-    Laser_on: bpy.props.StringProperty(name="Laser ON string", default="M68 E0 Q100")
-    Laser_off: bpy.props.StringProperty(name="Laser OFF string", default="M68 E0 Q0")
-    Laser_cmd: bpy.props.StringProperty(name="Laser command", default="M68 E0 Q")
-    Laser_delay: bpy.props.FloatProperty(name="Laser ON Delay",
-                                         description="time after fast move to turn on laser and let machine stabilize",
-                                         default=0.2)
-    Plasma_on: bpy.props.StringProperty(name="Plasma ON string", default="M03")
-    Plasma_off: bpy.props.StringProperty(name="Plasma OFF string", default="M05")
-    Plasma_delay: bpy.props.FloatProperty(name="Plasma ON Delay",
-                                          description="time after fast move to turn on Plasma and let machine stabilize",
-                                          default=0.1)
-    Plasma_dwell: bpy.props.FloatProperty(name="Plasma dwell time", description="Time to dwell and warm up the torch",
-                                          default=0.0)
+    Laser_on: StringProperty(
+        name="Laser ON string",
+        default="M68 E0 Q100",
+    )
+    Laser_off: StringProperty(
+        name="Laser OFF string",
+        default="M68 E0 Q0",
+    )
+    Laser_cmd: StringProperty(
+        name="Laser command",
+        default="M68 E0 Q",
+    )
+    Laser_delay: FloatProperty(
+        name="Laser ON Delay",
+        description="time after fast move to turn on laser and "
+        "let machine stabilize",
+        default=0.2,
+    )
+    Plasma_on: StringProperty(
+        name="Plasma ON string",
+        default="M03",
+    )
+    Plasma_off: StringProperty(
+        name="Plasma OFF string",
+        default="M05",
+    )
+    Plasma_delay: FloatProperty(
+        name="Plasma ON Delay",
+        description="time after fast move to turn on Plasma and "
+        "let machine stabilize",
+        default=0.1,
+    )
+    Plasma_dwell: FloatProperty(
+        name="Plasma dwell time",
+        description="Time to dwell and warm up the torch",
+        default=0.0,
+    )
 
     # steps
-    dist_between_paths: bpy.props.FloatProperty(name="Distance between toolpaths", default=0.001, min=0.00001, max=32,
-                                                precision=cam.constants.PRECISION, unit="LENGTH", update=updateRest)
-    dist_along_paths: bpy.props.FloatProperty(name="Distance along toolpaths", default=0.0002, min=0.00001, max=32,
-                                              precision=cam.constants.PRECISION, unit="LENGTH", update=updateRest)
-    parallel_angle: bpy.props.FloatProperty(name="Angle of paths", default=0, min=-360, max=360, precision=0,
-                                            subtype="ANGLE", unit="ROTATION", update=updateRest)
-    old_rotation_A: bpy.props.FloatProperty(name="A axis angle",
-                                            description="old value of Rotate A axis\nto specified angle", default=0,
-                                            min=-360, max=360, precision=0, subtype="ANGLE", unit="ROTATION",
-                                            update=updateRest)
+    dist_between_paths: FloatProperty(
+        name="Distance between toolpaths",
+        default=0.001,
+        min=0.00001,
+        max=32,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
+    dist_along_paths: FloatProperty(
+        name="Distance along toolpaths",
+        default=0.0002,
+        min=0.00001,
+        max=32,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
+    parallel_angle: FloatProperty(
+        name="Angle of paths",
+        default=0,
+        min=-360,
+        max=360,
+        precision=0,
+        subtype="ANGLE",
+        unit="ROTATION",
+        update=updateRest,
+    )
 
-    old_rotation_B: bpy.props.FloatProperty(name="A axis angle",
-                                            description="old value of Rotate A axis\nto specified angle", default=0,
-                                            min=-360, max=360, precision=0, subtype="ANGLE", unit="ROTATION",
-                                            update=updateRest)
+    old_rotation_A: FloatProperty(
+        name="A axis angle",
+        description="old value of Rotate A axis\nto specified angle",
+        default=0,
+        min=-360,
+        max=360,
+        precision=0,
+        subtype="ANGLE",
+        unit="ROTATION",
+        update=updateRest,
+    )
 
-    rotation_A: bpy.props.FloatProperty(name="A axis angle", description="Rotate A axis\nto specified angle", default=0,
-                                        min=-360, max=360, precision=0,
-                                        subtype="ANGLE", unit="ROTATION", update=updateRotation)
-    enable_A: bpy.props.BoolProperty(name="Enable A axis", description="Rotate A axis", default=False,
-                                     update=updateRotation)
-    A_along_x: bpy.props.BoolProperty(
-        name="A Along X ", description="A Parallel to X", default=True, update=updateRest)
+    old_rotation_B: FloatProperty(
+        name="A axis angle",
+        description="old value of Rotate A axis\nto specified angle",
+        default=0,
+        min=-360,
+        max=360,
+        precision=0,
+        subtype="ANGLE",
+        unit="ROTATION",
+        update=updateRest,
+    )
 
-    rotation_B: bpy.props.FloatProperty(name="B axis angle", description="Rotate B axis\nto specified angle", default=0,
-                                        min=-360, max=360, precision=0,
-                                        subtype="ANGLE", unit="ROTATION", update=updateRotation)
-    enable_B: bpy.props.BoolProperty(name="Enable B axis", description="Rotate B axis", default=False,
-                                     update=updateRotation)
+    rotation_A: FloatProperty(
+        name="A axis angle",
+        description="Rotate A axis\nto specified angle",
+        default=0,
+        min=-360,
+        max=360,
+        precision=0,
+        subtype="ANGLE",
+        unit="ROTATION",
+        update=updateRotation,
+    )
+    enable_A: BoolProperty(
+        name="Enable A axis",
+        description="Rotate A axis",
+        default=False,
+        update=updateRotation,
+    )
+    A_along_x: BoolProperty(
+        name="A Along X ",
+        description="A Parallel to X",
+        default=True,
+        update=updateRest,
+    )
+
+    rotation_B: FloatProperty(
+        name="B axis angle",
+        description="Rotate B axis\nto specified angle",
+        default=0,
+        min=-360,
+        max=360,
+        precision=0,
+        subtype="ANGLE",
+        unit="ROTATION",
+        update=updateRotation,
+    )
+    enable_B: BoolProperty(
+        name="Enable B axis",
+        description="Rotate B axis",
+        default=False,
+        update=updateRotation,
+    )
 
     # carve only
-    carve_depth: bpy.props.FloatProperty(name="Carve depth", default=0.001, min=-.100, max=32, precision=cam.constants.PRECISION,
-                                         unit="LENGTH", update=updateRest)
+    carve_depth: FloatProperty(
+        name="Carve depth",
+        default=0.001,
+        min=-.100,
+        max=32,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
 
     # drill only
-    drill_type: EnumProperty(name='Holes on', items=(
-        ('MIDDLE_SYMETRIC', 'Middle of symetric curves',
-         'a'), ('MIDDLE_ALL', 'Middle of all curve parts', 'a'),
-        ('ALL_POINTS', 'All points in curve', 'a')), description='Strategy to detect holes to drill',
-        default='MIDDLE_SYMETRIC', update=updateRest)
+    drill_type: EnumProperty(
+        name='Holes on',
+        items=(
+            ('MIDDLE_SYMETRIC', 'Middle of symetric curves', 'a'),
+            ('MIDDLE_ALL', 'Middle of all curve parts', 'a'),
+            ('ALL_POINTS', 'All points in curve', 'a')
+        ),
+        description='Strategy to detect holes to drill',
+        default='MIDDLE_SYMETRIC',
+        update=updateRest,
+    )
     # waterline only
-    slice_detail: bpy.props.FloatProperty(name="Distance betwen slices", default=0.001, min=0.00001, max=32,
-                                          precision=cam.constants.PRECISION, unit="LENGTH", update=updateRest)
-    waterline_fill: bpy.props.BoolProperty(name="Fill areas between slices",
-                                           description="Fill areas between slices in waterline mode", default=True,
-                                           update=updateRest)
-    waterline_project: bpy.props.BoolProperty(name="Project paths - not recomended",
-                                              description="Project paths in areas between slices", default=True,
-                                              update=updateRest)
+    slice_detail: FloatProperty(
+        name="Distance betwen slices",
+        default=0.001,
+        min=0.00001,
+        max=32,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
+    waterline_fill: BoolProperty(
+        name="Fill areas between slices",
+        description="Fill areas between slices in waterline mode",
+        default=True,
+        update=updateRest,
+    )
+    waterline_project: BoolProperty(
+        name="Project paths - not recomended",
+        description="Project paths in areas between slices",
+        default=True,
+        update=updateRest,
+    )
 
     # movement and ramps
-    use_layers: bpy.props.BoolProperty(name="Use Layers", description="Use layers for roughing", default=True,
-                                       update=updateRest)
-    stepdown: bpy.props.FloatProperty(name="", description="Layer height", default=0.01, min=0.00001, max=32, precision=cam.constants.PRECISION,
-                                      unit="LENGTH", update=updateRest)
-    lead_in: bpy.props.FloatProperty(name="Lead in radius",
-                                     description="Lead out radius for torch or laser to turn off",
-                                     min=0.00, max=1, default=0.0, precision=cam.constants.PRECISION, unit="LENGTH")
-    lead_out: bpy.props.FloatProperty(name="Lead out radius",
-                                      description="Lead out radius for torch or laser to turn off",
-                                      min=0.00, max=1, default=0.0, precision=cam.constants.PRECISION, unit="LENGTH")
-    profile_start: bpy.props.IntProperty(name="Start point", description="Start point offset", min=0, default=0,
-                                         update=updateRest)
+    use_layers: BoolProperty(
+        name="Use Layers",
+        description="Use layers for roughing",
+        default=True,
+        update=updateRest,
+    )
+    stepdown: FloatProperty(
+        name="",
+        description="Layer height",
+        default=0.01,
+        min=0.00001,
+        max=32,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
+    lead_in: FloatProperty(
+        name="Lead in radius",
+        description="Lead out radius for torch or laser to turn off",
+        min=0.00,
+        max=1,
+        default=0.0,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+    )
+    lead_out: FloatProperty(
+        name="Lead out radius",
+        description="Lead out radius for torch or laser to turn off",
+        min=0.00,
+        max=1,
+        default=0.0,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+    )
+    profile_start: IntProperty(
+        name="Start point",
+        description="Start point offset",
+        min=0,
+        default=0,
+        update=updateRest,
+    )
 
-    # helix_angle: bpy.props.FloatProperty(name="Helix ramp angle", default=3*math.pi/180, min=0.00001, max=math.pi*0.4999,precision=1, subtype="ANGLE" , unit="ROTATION" , update = updateRest)
+    # helix_angle: FloatProperty(name="Helix ramp angle", default=3*math.pi/180, min=0.00001, max=math.pi*0.4999,precision=1, subtype="ANGLE" , unit="ROTATION" , update = updateRest)
 
-    minz: bpy.props.FloatProperty(name="Operation depth end",
-                                  default=-0.01, min=-3, max=3, precision=cam.constants.PRECISION,
-                                  unit="LENGTH",
-                                  update=updateRest)
+    minz: FloatProperty(
+        name="Operation depth end",
+        default=-0.01,
+        min=-3,
+        max=3,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
 
-    minz_from: bpy.props.EnumProperty(name='Set max depth from',
-                                      description='Set maximum operation depth',
-                                      items=(
-                                          ('OBJECT', 'Object', 'Set max operation depth from Object'),
-                                          ('MATERIAL', 'Material', 'Set max operation depth from Material'),
-                                          ('CUSTOM', 'Custom', 'Custom max depth'),
-                                      ),
-                                      default='OBJECT',
-                                      update=updateRest
-                                      )
+    minz_from: EnumProperty(
+        name='Set max depth from',
+        description='Set maximum operation depth',
+        items=(
+            ('OBJECT', 'Object', 'Set max operation depth from Object'),
+            ('MATERIAL', 'Material', 'Set max operation depth from Material'),
+            ('CUSTOM', 'Custom', 'Custom max depth'),
+        ),
+        default='OBJECT',
+        update=updateRest,
+    )
 
-    start_type: bpy.props.EnumProperty(name='Start type',
-                                       items=(
-                                           ('ZLEVEL', 'Z level', 'Starts on a given Z level'),
-                                           ('OPERATIONRESULT', 'Rest milling',
-                                            'For rest milling, operations have to be put in chain for this to work well.'),
-                                       ),
-                                       description='Starting depth',
-                                       default='ZLEVEL',
-                                       update=updateStrategy)
+    start_type: EnumProperty(
+        name='Start type',
+        items=(
+            ('ZLEVEL', 'Z level', 'Starts on a given Z level'),
+            ('OPERATIONRESULT', 'Rest milling',
+             'For rest milling, operations have to be '
+             'put in chain for this to work well.'),
+        ),
+        description='Starting depth',
+        default='ZLEVEL',
+        update=updateStrategy,
+    )
 
-    maxz: bpy.props.FloatProperty(name="Operation depth start", description='operation starting depth', default=0,
-                                  min=-3, max=10, precision=cam.constants.PRECISION, unit="LENGTH",
-                                  update=updateRest)  # EXPERIMENTAL
+    maxz: FloatProperty(
+        name="Operation depth start",
+        description='operation starting depth',
+        default=0,
+        min=-3,
+        max=10,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )  # EXPERIMENTAL
 
-    first_down: bpy.props.BoolProperty(name="First down",
-                                       description="First go down on a contour, then go to the next one",
-                                       default=False, update=cam.utils.update_operation)
+    first_down: BoolProperty(
+        name="First down",
+        description="First go down on a contour, then go to the next one",
+        default=False,
+        update=cam.utils.update_operation,
+    )
 
     #######################################################
     # Image related
     ####################################################
 
-    source_image_scale_z: bpy.props.FloatProperty(name="Image source depth scale", default=0.01, min=-1, max=1,
-                                                  precision=cam.constants.PRECISION, unit="LENGTH", update=updateZbufferImage)
-    source_image_size_x: bpy.props.FloatProperty(name="Image source x size", default=0.1, min=-10, max=10,
-                                                 precision=cam.constants.PRECISION, unit="LENGTH", update=updateZbufferImage)
-    source_image_offset: bpy.props.FloatVectorProperty(name='Image offset', default=(0, 0, 0), unit='LENGTH',
-                                                       precision=cam.constants.PRECISION, subtype="XYZ", update=updateZbufferImage)
-    source_image_crop: bpy.props.BoolProperty(name="Crop source image",
-                                              description="Crop source image - the position of the sub-rectangle is relative to the whole image, so it can be used for e.g. finishing just a part of an image",
-                                              default=False, update=updateZbufferImage)
-    source_image_crop_start_x: bpy.props.FloatProperty(name='crop start x', default=0, min=0, max=100,
-                                                       precision=cam.constants.PRECISION, subtype='PERCENTAGE',
-                                                       update=updateZbufferImage)
-    source_image_crop_start_y: bpy.props.FloatProperty(name='crop start y', default=0, min=0, max=100,
-                                                       precision=cam.constants.PRECISION, subtype='PERCENTAGE',
-                                                       update=updateZbufferImage)
-    source_image_crop_end_x: bpy.props.FloatProperty(name='crop end x', default=100, min=0, max=100,
-                                                     precision=cam.constants.PRECISION, subtype='PERCENTAGE',
-                                                     update=updateZbufferImage)
-    source_image_crop_end_y: bpy.props.FloatProperty(name='crop end y', default=100, min=0, max=100,
-                                                     precision=cam.constants.PRECISION, subtype='PERCENTAGE',
-                                                     update=updateZbufferImage)
+    source_image_scale_z: FloatProperty(
+        name="Image source depth scale",
+        default=0.01,
+        min=-1,
+        max=1,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateZbufferImage,
+    )
+    source_image_size_x: FloatProperty(
+        name="Image source x size",
+        default=0.1,
+        min=-10,
+        max=10,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateZbufferImage,
+    )
+    source_image_offset: FloatVectorProperty(
+        name='Image offset',
+        default=(0, 0, 0),
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        subtype="XYZ",
+        update=updateZbufferImage,
+    )
+
+    source_image_crop: BoolProperty(
+        name="Crop source image",
+        description="Crop source image - the position of the sub-rectangle "
+        "is relative to the whole image, so it can be used for e.g. "
+        "finishing just a part of an image",
+        default=False,
+        update=updateZbufferImage,
+    )
+    source_image_crop_start_x: FloatProperty(
+        name='crop start x',
+        default=0,
+        min=0,
+        max=100,
+        precision=cam.constants.PRECISION,
+        subtype='PERCENTAGE',
+        update=updateZbufferImage,
+    )
+    source_image_crop_start_y: FloatProperty(
+        name='crop start y',
+        default=0,
+        min=0,
+        max=100,
+        precision=cam.constants.PRECISION,
+        subtype='PERCENTAGE',
+        update=updateZbufferImage,
+    )
+    source_image_crop_end_x: FloatProperty(
+        name='crop end x',
+        default=100,
+        min=0,
+        max=100,
+        precision=cam.constants.PRECISION,
+        subtype='PERCENTAGE',
+        update=updateZbufferImage,
+    )
+    source_image_crop_end_y: FloatProperty(
+        name='crop end y',
+        default=100,
+        min=0,
+        max=100,
+        precision=cam.constants.PRECISION,
+        subtype='PERCENTAGE',
+        update=updateZbufferImage,
+    )
 
     #########################################################
     # Toolpath and area related
     #####################################################
 
-    ambient_behaviour: EnumProperty(name='Ambient', items=(('ALL', 'All', 'a'), ('AROUND', 'Around', 'a')),
-                                    description='handling ambient surfaces', default='ALL', update=updateZbufferImage)
+    ambient_behaviour: EnumProperty(
+        name='Ambient',
+        items=(('ALL', 'All', 'a'), ('AROUND', 'Around', 'a')),
+        description='handling ambient surfaces',
+        default='ALL',
+        update=updateZbufferImage,
+    )
 
-    ambient_radius: FloatProperty(name="Ambient radius",
-                                  description="Radius around the part which will be milled if ambient is set to Around",
-                                  min=0.0, max=100.0, default=0.01, precision=cam.constants.PRECISION, unit="LENGTH",
-                                  update=updateRest)
+    ambient_radius: FloatProperty(
+        name="Ambient radius",
+        description="Radius around the part which will be milled if "
+        "ambient is set to Around",
+        min=0.0,
+        max=100.0,
+        default=0.01,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
     # ambient_cutter = EnumProperty(name='Borders',items=(('EXTRAFORCUTTER', 'Extra for cutter', "Extra space for cutter is cut around the segment"),('ONBORDER', "Cutter on edge", "Cutter goes exactly on edge of ambient with it's middle") ,('INSIDE', "Inside segment", 'Cutter stays within segment')	 ),description='handling of ambient and cutter size',default='INSIDE')
-    use_limit_curve: bpy.props.BoolProperty(name="Use limit curve", description="A curve limits the operation area",
-                                            default=False, update=updateRest)
-    ambient_cutter_restrict: bpy.props.BoolProperty(name="Cutter stays in ambient limits",
-                                                    description="Cutter doesn't get out from ambient limits otherwise goes on the border exactly",
-                                                    default=True,
-                                                    update=updateRest)  # restricts cutter inside ambient only
-    limit_curve: bpy.props.StringProperty(name='Limit curve',
-                                          description='curve used to limit the area of the operation',
-                                          update=updateRest)
+    use_limit_curve: BoolProperty(
+        name="Use limit curve",
+        description="A curve limits the operation area",
+        default=False,
+        update=updateRest,
+    )
+    ambient_cutter_restrict: BoolProperty(
+        name="Cutter stays in ambient limits",
+        description="Cutter doesn't get out from ambient limits otherwise "
+        "goes on the border exactly",
+        default=True,
+        update=updateRest,
+    )  # restricts cutter inside ambient only
+    limit_curve: StringProperty(
+        name='Limit curve',
+        description='curve used to limit the area of the operation',
+        update=updateRest,
+    )
 
     # feeds
-    feedrate: FloatProperty(name="Feedrate", description="Feedrate in units per minute", min=0.00005, max=50.0, default=1.0,
-                            precision=cam.constants.PRECISION, unit="LENGTH", update=updateChipload)
-    plunge_feedrate: FloatProperty(name="Plunge speed ", description="% of feedrate", min=0.1, max=100.0, default=50.0,
-                                   precision=1, subtype='PERCENTAGE', update=updateRest)
-    plunge_angle: bpy.props.FloatProperty(name="Plunge angle",
-                                          description="What angle is allready considered to plunge",
-                                          default=math.pi / 6, min=0, max=math.pi * 0.5, precision=0, subtype="ANGLE",
-                                          unit="ROTATION", update=updateRest)
-    spindle_rpm: FloatProperty(name="Spindle rpm", description="Spindle speed ", min=0, max=60000, default=12000,
-                               update=updateChipload)
+    feedrate: FloatProperty(
+        name="Feedrate",
+        description="Feedrate in units per minute",
+        min=0.00005,
+        max=50.0,
+        default=1.0,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateChipload,
+    )
+    plunge_feedrate: FloatProperty(
+        name="Plunge speed ",
+        description="% of feedrate",
+        min=0.1,
+        max=100.0,
+        default=50.0,
+        precision=1,
+        subtype='PERCENTAGE',
+        update=updateRest,
+    )
+    plunge_angle: FloatProperty(
+        name="Plunge angle",
+        description="What angle is allready considered to plunge",
+        default=math.pi / 6,
+        min=0,
+        max=math.pi * 0.5,
+        precision=0,
+        subtype="ANGLE",
+        unit="ROTATION",
+        update=updateRest,
+    )
+    spindle_rpm: FloatProperty(
+        name="Spindle rpm",
+        description="Spindle speed ",
+        min=0,
+        max=60000,
+        default=12000,
+        update=updateChipload,
+    )
 
     # optimization and performance
 
-    do_simulation_feedrate: bpy.props.BoolProperty(name="Adjust feedrates with simulation EXPERIMENTAL",
-                                                   description="Adjust feedrates with simulation", default=False,
-                                                   update=updateRest)
+    do_simulation_feedrate: BoolProperty(
+        name="Adjust feedrates with simulation EXPERIMENTAL",
+        description="Adjust feedrates with simulation",
+        default=False,
+        update=updateRest,
+    )
 
-    dont_merge: bpy.props.BoolProperty(name="Dont merge outlines when cutting",
-                                       description="this is usefull when you want to cut around everything",
-                                       default=False, update=updateRest)
+    dont_merge: BoolProperty(
+        name="Dont merge outlines when cutting",
+        description="this is usefull when you want to cut around everything",
+        default=False,
+        update=updateRest,
+    )
 
-    pencil_threshold: bpy.props.FloatProperty(name="Pencil threshold", default=0.00002, min=0.00000001, max=1,
-                                              precision=cam.constants.PRECISION, unit="LENGTH", update=updateRest)
-    crazy_threshold1: bpy.props.FloatProperty(name="min engagement", default=0.02, min=0.00000001, max=100,
-                                              precision=cam.constants.PRECISION, update=updateRest)
-    crazy_threshold5: bpy.props.FloatProperty(name="optimal engagement", default=0.3, min=0.00000001, max=100,
-                                              precision=cam.constants.PRECISION, update=updateRest)
-    crazy_threshold2: bpy.props.FloatProperty(name="max engagement", default=0.5, min=0.00000001, max=100,
-                                              precision=cam.constants.PRECISION, update=updateRest)
-    crazy_threshold3: bpy.props.FloatProperty(name="max angle", default=2, min=0.00000001, max=100,
-                                              precision=cam.constants.PRECISION, update=updateRest)
-    crazy_threshold4: bpy.props.FloatProperty(name="test angle step", default=0.05, min=0.00000001, max=100,
-                                              precision=cam.constants.PRECISION, update=updateRest)
+    pencil_threshold: FloatProperty(
+        name="Pencil threshold",
+        default=0.00002,
+        min=0.00000001,
+        max=1,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
+
+    crazy_threshold1: FloatProperty(
+        name="min engagement",
+        default=0.02,
+        min=0.00000001,
+        max=100,
+        precision=cam.constants.PRECISION,
+        update=updateRest,
+    )
+    crazy_threshold5: FloatProperty(
+        name="optimal engagement",
+        default=0.3,
+        min=0.00000001,
+        max=100,
+        precision=cam.constants.PRECISION,
+        update=updateRest,
+    )
+    crazy_threshold2: FloatProperty(
+        name="max engagement",
+        default=0.5,
+        min=0.00000001,
+        max=100,
+        precision=cam.constants.PRECISION,
+        update=updateRest,
+    )
+    crazy_threshold3: FloatProperty(
+        name="max angle",
+        default=2,
+        min=0.00000001,
+        max=100,
+        precision=cam.constants.PRECISION,
+        update=updateRest,
+    )
+    crazy_threshold4: FloatProperty(
+        name="test angle step",
+        default=0.05,
+        min=0.00000001,
+        max=100,
+        precision=cam.constants.PRECISION,
+        update=updateRest,
+    )
     # Add pocket operation to medial axis
-    add_pocket_for_medial: bpy.props.BoolProperty(name="Add pocket operation",
-                                                  description="clean unremoved material after medial axis",
-                                                  default=True,
-                                                  update=updateRest)
+    add_pocket_for_medial: BoolProperty(
+        name="Add pocket operation",
+        description="clean unremoved material after medial axis",
+        default=True,
+        update=updateRest,
+    )
 
-    add_mesh_for_medial: bpy.props.BoolProperty(name="Add Medial mesh",
-                                                description="Medial operation returns mesh for editing and further processing",
-                                                default=False,
-                                                update=updateRest)
+    add_mesh_for_medial: BoolProperty(
+        name="Add Medial mesh",
+        description="Medial operation returns mesh for editing and "
+        "further processing",
+        default=False,
+        update=updateRest,
+    )
     ####
-    medial_axis_threshold: bpy.props.FloatProperty(name="Long vector threshold", default=0.001, min=0.00000001,
-                                                   max=100, precision=cam.constants.PRECISION, unit="LENGTH", update=updateRest)
-    medial_axis_subdivision: bpy.props.FloatProperty(name="Fine subdivision", default=0.0002, min=0.00000001, max=100,
-                                                     precision=cam.constants.PRECISION, unit="LENGTH", update=updateRest)
+    medial_axis_threshold: FloatProperty(
+        name="Long vector threshold",
+        default=0.001,
+        min=0.00000001,
+        max=100,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
+    medial_axis_subdivision: FloatProperty(
+        name="Fine subdivision",
+        default=0.0002,
+        min=0.00000001,
+        max=100,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=updateRest,
+    )
     # calculations
 
     # bridges
-    use_bridges: bpy.props.BoolProperty(name="Use bridges", description="use bridges in cutout", default=False,
-                                        update=updateBridges)
-    bridges_width: bpy.props.FloatProperty(name='width of bridges', default=0.002, unit='LENGTH', precision=cam.constants.PRECISION,
-                                           update=updateBridges)
-    bridges_height: bpy.props.FloatProperty(name='height of bridges',
-                                            description="Height from the bottom of the cutting operation",
-                                            default=0.0005, unit='LENGTH', precision=cam.constants.PRECISION, update=updateBridges)
-    bridges_collection_name: bpy.props.StringProperty(name='Bridges Collection',
-                                                      description='Collection of curves used as bridges',
-                                                      update=operationValid)
-    use_bridge_modifiers: BoolProperty(name="use bridge modifiers",
-                                       description="include bridge curve modifiers using render level when calculating operation, does not effect original bridge data",
-                                       default=True, update=updateBridges)
+    use_bridges: BoolProperty(
+        name="Use bridges",
+        description="use bridges in cutout",
+        default=False,
+        update=updateBridges,
+    )
+    bridges_width: FloatProperty(
+        name='width of bridges',
+        default=0.002,
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        update=updateBridges,
+    )
+    bridges_height: FloatProperty(
+        name='height of bridges',
+        description="Height from the bottom of the cutting operation",
+        default=0.0005,
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        update=updateBridges,
+    )
+    bridges_collection_name: StringProperty(
+        name='Bridges Collection',
+        description='Collection of curves used as bridges',
+        update=operationValid,
+    )
+    use_bridge_modifiers: BoolProperty(
+        name="use bridge modifiers",
+        description="include bridge curve modifiers using render level when "
+        "calculating operation, does not effect original bridge data",
+        default=True,
+        update=updateBridges,
+    )
 
     # commented this - auto bridges will be generated, but not as a setting of the operation
-    # bridges_placement = bpy.props.EnumProperty(name='Bridge placement',
+    # bridges_placement = EnumProperty(name='Bridge placement',
     #     items=(
     #         ('AUTO','Automatic', 'Automatic bridges with a set distance'),
     #         ('MANUAL','Manual', 'Manual placement of bridges'),
@@ -975,12 +1711,16 @@ class camOperation(bpy.types.PropertyGroup):
     #     default='AUTO',
     #     update = updateStrategy)
     #
-    # bridges_per_curve = bpy.props.IntProperty(name="minimum bridges per curve", description="", default=4, min=1, max=512, update = updateBridges)
-    # bridges_max_distance = bpy.props.FloatProperty(name = 'Maximum distance between bridges', default=0.08, unit='LENGTH', precision=cam.constants.PRECISION, update = updateBridges)
+    # bridges_per_curve = IntProperty(name="minimum bridges per curve", description="", default=4, min=1, max=512, update = updateBridges)
+    # bridges_max_distance = FloatProperty(name = 'Maximum distance between bridges', default=0.08, unit='LENGTH', precision=cam.constants.PRECISION, update = updateBridges)
 
-    use_modifiers: BoolProperty(name="use mesh modifiers",
-                                description="include mesh modifiers using render level when calculating operation, does not effect original mesh",
-                                default=True, update=operationValid)
+    use_modifiers: BoolProperty(
+        name="use mesh modifiers",
+        description="include mesh modifiers using render level when "
+        "calculating operation, does not effect original mesh",
+        default=True,
+        update=operationValid,
+    )
     # optimisation panel
 
     # material settings
@@ -989,69 +1729,111 @@ class camOperation(bpy.types.PropertyGroup):
 ##############################################################################
     # MATERIAL SETTINGS
 
-    min: bpy.props.FloatVectorProperty(
-        name='Operation minimum', default=(0, 0, 0), unit='LENGTH', precision=cam.constants.PRECISION,
-        subtype="XYZ")
-    max: bpy.props.FloatVectorProperty(name='Operation maximum', default=(0, 0, 0), unit='LENGTH', precision=cam.constants.PRECISION,
-                                       subtype="XYZ")
+    min: FloatVectorProperty(
+        name='Operation minimum',
+        default=(0, 0, 0),
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        subtype="XYZ",
+    )
+    max: FloatVectorProperty(
+        name='Operation maximum',
+        default=(0, 0, 0),
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        subtype="XYZ",
+    )
 
     # g-code options for operation
-    output_header: BoolProperty(name="output g-code header",
-                                description="output user defined g-code command header at start of operation",
-                                default=False)
+    output_header: BoolProperty(
+        name="output g-code header",
+        description="output user defined g-code command header"
+        " at start of operation",
+        default=False,
+    )
 
-    gcode_header: StringProperty(name="g-code header",
-                                 description="g-code commands at start of operation. Use ; for line breaks",
-                                 default="G53 G0")
+    gcode_header: StringProperty(
+        name="g-code header",
+        description="g-code commands at start of operation."
+        " Use ; for line breaks",
+        default="G53 G0",
+    )
 
-    enable_dust: BoolProperty(name="Dust collector",
-                              description="output user defined g-code command header at start of operation",
-                              default=False)
+    enable_dust: BoolProperty(
+        name="Dust collector",
+        description="output user defined g-code command header"
+        " at start of operation",
+        default=False,
+    )
 
-    gcode_start_dust_cmd: StringProperty(name="Start dust collector",
-                                         description="commands to start dust collection. Use ; for line breaks",
-                                         default="M100")
+    gcode_start_dust_cmd: StringProperty(
+        name="Start dust collector",
+        description="commands to start dust collection. Use ; for line breaks",
+        default="M100",
+    )
 
-    gcode_stop_dust_cmd: StringProperty(name="Stop dust collector",
-                                        description="command to stop dust collection. Use ; for line breaks",
-                                        default="M101")
+    gcode_stop_dust_cmd: StringProperty(
+        name="Stop dust collector",
+        description="command to stop dust collection. Use ; for line breaks",
+        default="M101",
+    )
 
-    enable_hold: BoolProperty(name="Hold down",
-                              description="output hold down command at start of operation",
-                              default=False)
+    enable_hold: BoolProperty(
+        name="Hold down",
+        description="output hold down command at start of operation",
+        default=False,
+    )
 
-    gcode_start_hold_cmd: StringProperty(name="g-code header",
-                                         description="g-code commands at start of operation. Use ; for line breaks",
-                                         default="M102")
+    gcode_start_hold_cmd: StringProperty(
+        name="g-code header",
+        description="g-code commands at start of operation."
+        " Use ; for line breaks",
+        default="M102",
+    )
 
-    gcode_stop_hold_cmd: StringProperty(name="g-code header",
-                                        description="g-code commands at end operation. Use ; for line breaks",
-                                        default="M103")
+    gcode_stop_hold_cmd: StringProperty(
+        name="g-code header",
+        description="g-code commands at end operation. Use ; for line breaks",
+        default="M103",
+    )
 
-    enable_mist: BoolProperty(name="Mist",
-                              description="Mist command at start of operation",
-                              default=False)
+    enable_mist: BoolProperty(
+        name="Mist",
+        description="Mist command at start of operation",
+        default=False,
+    )
 
-    gcode_start_mist_cmd: StringProperty(name="g-code header",
-                                         description="g-code commands at start of operation. Use ; for line breaks",
-                                         default="M104")
+    gcode_start_mist_cmd: StringProperty(
+        name="g-code header",
+        description="g-code commands at start of operation."
+        " Use ; for line breaks",
+        default="M104",
+    )
 
-    gcode_stop_mist_cmd: StringProperty(name="g-code header",
-                                        description="g-code commands at end operation. Use ; for line breaks",
-                                        default="M105")
+    gcode_stop_mist_cmd: StringProperty(
+        name="g-code header",
+        description="g-code commands at end operation. Use ; for line breaks",
+        default="M105",
+    )
 
-    output_trailer: BoolProperty(name="output g-code trailer",
-                                 description="output user defined g-code command trailer at end of operation",
-                                 default=False)
+    output_trailer: BoolProperty(
+        name="output g-code trailer",
+        description="output user defined g-code command trailer"
+        " at end of operation",
+        default=False,
+    )
 
-    gcode_trailer: StringProperty(name="g-code trailer",
-                                  description="g-code commands at end of operation. Use ; for line breaks",
-                                  default="M02")
+    gcode_trailer: StringProperty(
+        name="g-code trailer",
+        description="g-code commands at end of operation."
+        " Use ; for line breaks",
+        default="M02",
+    )
 
     # internal properties
     ###########################################
 
-    # testing = bpy.props.IntProperty(name="developer testing ", description="This is just for script authors for help in coding, keep 0", default=0, min=0, max=512)
+    # testing = IntProperty(name="developer testing ", description="This is just for script authors for help in coding, keep 0", default=0, min=0, max=512)
     offset_image = numpy.array([], dtype=float)
     zbuffer_image = numpy.array([], dtype=float)
 
@@ -1060,54 +1842,116 @@ class camOperation(bpy.types.PropertyGroup):
     operation_limit = sgeometry.Polygon()
     borderwidth = 50
     object = None
-    path_object_name: bpy.props.StringProperty(name='Path object', description='actual cnc path')
+    path_object_name: StringProperty(
+        name='Path object',
+        description='actual cnc path'
+    )
 
     # update and tags and related
 
-    changed: bpy.props.BoolProperty(name="True if any of the operation settings has changed",
-                                    description="mark for update", default=False)
-    update_zbufferimage_tag: bpy.props.BoolProperty(name="mark zbuffer image for update",
-                                                    description="mark for update", default=True)
-    update_offsetimage_tag: bpy.props.BoolProperty(name="mark offset image for update", description="mark for update",
-                                                   default=True)
-    update_silhouete_tag: bpy.props.BoolProperty(name="mark silhouete image for update", description="mark for update",
-                                                 default=True)
-    update_ambient_tag: bpy.props.BoolProperty(name="mark ambient polygon for update", description="mark for update",
-                                               default=True)
-    update_bullet_collision_tag: bpy.props.BoolProperty(name="mark bullet collisionworld for update",
-                                                        description="mark for update", default=True)
+    changed: BoolProperty(
+        name="True if any of the operation settings has changed",
+        description="mark for update",
+        default=False,
+    )
+    update_zbufferimage_tag: BoolProperty(
+        name="mark zbuffer image for update",
+        description="mark for update",
+        default=True,
+    )
+    update_offsetimage_tag: BoolProperty(
+        name="mark offset image for update",
+        description="mark for update",
+        default=True,
+    )
+    update_silhouete_tag: BoolProperty(
+        name="mark silhouete image for update",
+        description="mark for update",
+        default=True,
+    )
+    update_ambient_tag: BoolProperty(
+        name="mark ambient polygon for update",
+        description="mark for update",
+        default=True,
+    )
+    update_bullet_collision_tag: BoolProperty(
+        name="mark bullet collisionworld for update",
+        description="mark for update",
+        default=True,
+    )
 
-    valid: bpy.props.BoolProperty(
-        name="Valid", description="True if operation is ok for calculation", default=True)
-    changedata: bpy.props.StringProperty(
-        name='changedata', description='change data for checking if stuff changed.')
+    valid: BoolProperty(
+        name="Valid",
+        description="True if operation is ok for calculation",
+        default=True,
+    )
+    changedata: StringProperty(
+        name='changedata',
+        description='change data for checking if stuff changed.',
+    )
 
     # process related data
 
-    computing: bpy.props.BoolProperty(name="Computing right now", description="", default=False)
-    pid: bpy.props.IntProperty(name="process id", description="Background process id", default=-1)
-    outtext: bpy.props.StringProperty(name='outtext', description='outtext', default='')
+    computing: BoolProperty(
+        name="Computing right now",
+        description="",
+        default=False,
+    )
+    pid: IntProperty(
+        name="process id",
+        description="Background process id",
+        default=-1,
+    )
+    outtext: StringProperty(
+        name='outtext',
+        description='outtext',
+        default='',
+    )
 
 
 # this type is defined just to hold reference to operations for chains
 class opReference(bpy.types.PropertyGroup):
-    name: bpy.props.StringProperty(name="Operation name", default="Operation")
+    name: StringProperty(
+        name="Operation name",
+        default="Operation",
+    )
     computing = False  # for UiList display
 
 
 # chain is just a set of operations which get connected on export into 1 file.
 class camChain(bpy.types.PropertyGroup):
-    index: bpy.props.IntProperty(
-        name="index", description="index in the hard-defined camChains", default=-1)
-    active_operation: bpy.props.IntProperty(name="active operation", description="active operation in chain",
-                                            default=-1)
-    name: bpy.props.StringProperty(name="Chain Name", default="Chain")
-    filename: bpy.props.StringProperty(name="File name", default="Chain")  # filename of
-    valid: bpy.props.BoolProperty(
-        name="Valid", description="True if whole chain is ok for calculation", default=True)
-    computing: bpy.props.BoolProperty(name="Computing right now", description="", default=False)
+    index: IntProperty(
+        name="index",
+        description="index in the hard-defined camChains",
+        default=-1,
+    )
+    active_operation: IntProperty(
+        name="active operation",
+        description="active operation in chain",
+        default=-1,
+    )
+    name: StringProperty(
+        name="Chain Name",
+        default="Chain",
+    )
+    filename: StringProperty(
+        name="File name",
+        default="Chain",
+    )  # filename of
+    valid: BoolProperty(
+        name="Valid",
+        description="True if whole chain is ok for calculation",
+        default=True,
+    )
+    computing: BoolProperty(
+        name="Computing right now",
+        description="",
+        default=False,
+    )
     # this is to hold just operation names.
-    operations: bpy.props.CollectionProperty(type=opReference)
+    operations: CollectionProperty(
+        type=opReference,
+    )
 
 
 class CAM_CUTTER_MT_presets(Menu):
@@ -1594,28 +2438,47 @@ def register():
 
     s = bpy.types.Scene
 
-    s.cam_chains = bpy.props.CollectionProperty(type=camChain)
-    s.cam_active_chain = bpy.props.IntProperty(
-        name="CAM Active Chain", description="The selected chain")
+    s.cam_chains = CollectionProperty(
+        type=camChain,
+    )
+    s.cam_active_chain = IntProperty(
+        name="CAM Active Chain",
+        description="The selected chain",
+    )
 
-    s.cam_operations = bpy.props.CollectionProperty(type=camOperation)
+    s.cam_operations = CollectionProperty(
+        type=camOperation,
+    )
 
-    s.cam_active_operation = bpy.props.IntProperty(name="CAM Active Operation", description="The selected operation",
-                                                   update=updateOperation)
-    s.cam_machine = bpy.props.PointerProperty(type=machineSettings)
+    s.cam_active_operation = IntProperty(
+        name="CAM Active Operation",
+        description="The selected operation",
+        update=updateOperation,
+    )
+    s.cam_machine = PointerProperty(
+        type=machineSettings,
+    )
 
-    s.cam_import_gcode = bpy.props.PointerProperty(type=import_settings)
+    s.cam_import_gcode = PointerProperty(
+        type=import_settings,
+    )
 
-    s.cam_text = bpy.props.StringProperty()
+    s.cam_text = StringProperty()
     bpy.app.handlers.frame_change_pre.append(ops.timer_update)
     bpy.app.handlers.load_post.append(check_operations_on_load)
     # bpy.types.INFO_HT_header.append(header_info)
 
-    s.cam_pack = bpy.props.PointerProperty(type=PackObjectsSettings)
+    s.cam_pack = PointerProperty(
+        type=PackObjectsSettings,
+    )
 
-    s.cam_slice = bpy.props.PointerProperty(type=SliceObjectsSettings)
+    s.cam_slice = PointerProperty(
+        type=SliceObjectsSettings,
+    )
 
-    bpy.types.Scene.interface = bpy.props.PointerProperty(type=CAM_INTERFACE_Properties)
+    bpy.types.Scene.interface = PointerProperty(
+        type=CAM_INTERFACE_Properties,
+    )
 
     basrelief.register()
 

--- a/scripts/addons/cam/autoupdate.py
+++ b/scripts/addons/cam/autoupdate.py
@@ -5,6 +5,8 @@ import json
 import pathlib
 import zipfile
 import bpy
+from bpy.props import StringProperty
+
 import re
 import io
 import os
@@ -114,7 +116,8 @@ class Updater(bpy.types.Operator):
                 commit_sha = commit_list[0]['sha']
                 if bpy.context.preferences.addons['cam'].preferences.last_commit_hash != commit_sha:
                     # get zipball from this commit
-                    zip_url = update_source.replace("/commits", f"/zipball/{commit_sha}")
+                    zip_url = update_source.replace(
+                        "/commits", f"/zipball/{commit_sha}")
                     self.install_zip_from_url(zip_url)
                     bpy.context.preferences.addons['cam'].preferences.last_commit_hash = commit_sha
                     bpy.ops.wm.save_userpref()
@@ -130,9 +133,11 @@ class Updater(bpy.types.Operator):
             for fileinfo in files:
                 filename = fileinfo.filename
                 if fileinfo.is_dir() == False:
-                    path_pos = filename.replace("\\", "/").find("/scripts/addons/cam/")
+                    path_pos = filename.replace(
+                        "\\", "/").find("/scripts/addons/cam/")
                     if path_pos != -1:
-                        relative_path = filename[path_pos+len("/scripts/addons/cam/"):]
+                        relative_path = filename[path_pos +
+                                                 len("/scripts/addons/cam/"):]
                         out_path = cam_addon_path / relative_path
                         print(out_path)
                         # check folder exists
@@ -162,7 +167,9 @@ class UpdateSourceOperator(bpy.types.Operator):
     bl_idname = "render.cam_set_update_source"
     bl_label = "Set blendercam update source"
 
-    new_source: bpy.props.StringProperty(default='')
+    new_source: StringProperty(
+        default='',
+    )
 
     def execute(self, context):
         bpy.context.preferences.addons['cam'].preferences.update_source = self.new_source

--- a/scripts/addons/cam/basrelief.py
+++ b/scripts/addons/cam/basrelief.py
@@ -48,7 +48,8 @@ def restrictbuf(inbuf, outbuf):  # scale down array....
         # if dx<2:
         # restricted=
         # num=restricted.shape[0]*restricted.shape[1]
-        outbuf[:] = (inbuf[::2, ::2]+inbuf[1::2, ::2]+inbuf[::2, 1::2]+inbuf[1::2, 1::2])/4.0
+        outbuf[:] = (inbuf[::2, ::2]+inbuf[1::2, ::2] +
+                     inbuf[::2, 1::2]+inbuf[1::2, 1::2])/4.0
 
     elif NUMPYALG:  # numpy method
         yrange = numpy.arange(0, outy)
@@ -78,7 +79,8 @@ def restrictbuf(inbuf, outbuf):  # scale down array....
 
         indices[0] = sxstartrange.repeat(outy)
 
-        indices[1] = systartrange.repeat(outx).reshape(outx, outy).swapaxes(0, 1).flatten()
+        indices[1] = systartrange.repeat(outx).reshape(
+            outx, outy).swapaxes(0, 1).flatten()
 
         # systartrange=numpy.max(0,numpy.ceil(syrange-xfiltersize))
         # syendrange=numpy.min(numpy.floor(syrange+xfiltersize),iny-1)+1
@@ -153,7 +155,8 @@ def prolongate(inbuf, outbuf):
 
         indices = numpy.arange(outx*outy*2).reshape((2, outx*outy))
         indices[0] = sxstartrange.repeat(outy)
-        indices[1] = systartrange.repeat(outx).reshape(outx, outy).swapaxes(0, 1).flatten()
+        indices[1] = systartrange.repeat(outx).reshape(
+            outx, outy).swapaxes(0, 1).flatten()
 
         # systartrange=numpy.max(0,numpy.ceil(syrange-xfiltersize))
         # syendrange=numpy.min(numpy.floor(syrange+xfiltersize),iny-1)+1
@@ -225,9 +228,11 @@ def calculate_defect(D, U, F):
         U[1:-1, :-2] - U[1:-1, 2:] + 4*U[1:-1, 1:-1]
     # sides
     D[1:-1, 0] = F[1:-1, 0] - U[:-2, 0] - U[2:, 0] - U[1:-1, 1] + 3*U[1:-1, 0]
-    D[1:-1, -1] = F[1:-1, -1] - U[:-2, -1] - U[2:, -1] - U[1:-1, -2] + 3*U[1:-1, -1]
+    D[1:-1, -1] = F[1:-1, -1] - U[:-2, -1] - \
+        U[2:, -1] - U[1:-1, -2] + 3*U[1:-1, -1]
     D[0, 1:-1] = F[0, 1:-1] - U[0, :-2] - U[0, :-2] - U[1, 1:-1] + 3*U[0, 1:-1]
-    D[-1, 1:-1] = F[-1, 1:-1] - U[-1, :-2] - U[-1, :-2] - U[-1, 1:-1] + 3*U[-1, 1:-1]
+    D[-1, 1:-1] = F[-1, 1:-1] - U[-1, :-2] - \
+        U[-1, :-2] - U[-1, 1:-1] + 3*U[-1, 1:-1]
     # coners
     D[0, 0] = F[0, 0] - U[0, 1] - U[1, 0] + 2*U[0, 0]
     D[0, -1] = F[0, -1] - U[1, -1] - U[0, -2] + 2*U[0, -1]
@@ -399,7 +404,8 @@ def asolve(b, x):
 
 
 def atimes(x, res):
-    res[1:-1, 1:-1] = x[:-2, 1:-1]+x[2:, 1:-1]+x[1:-1, :-2]+x[1:-1, 2:] - 4*x[1:-1, 1:-1]
+    res[1:-1, 1:-1] = x[:-2, 1:-1]+x[2:, 1:-1] + \
+        x[1:-1, :-2]+x[1:-1, 2:] - 4*x[1:-1, 1:-1]
     # sides
     res[1:-1, 0] = x[0:-2, 0]+x[2:, 0]+x[1:-1, 1] - 3*x[1:-1, 0]
     res[1:-1, -1] = x[0:-2, -1]+x[2:, -1]+x[1:-1, -2] - 3*x[1:-1, -1]
@@ -664,7 +670,8 @@ def buildMesh(mesh_z, br):
     ob = bpy.data.objects['BasReliefMesh']
     ob.select_set(True)
     bpy.context.view_layer.objects.active = ob
-    bpy.context.active_object.dimensions = (br.widthmm/1000, br.heightmm/1000, br.thicknessmm/1000)
+    bpy.context.active_object.dimensions = (
+        br.widthmm/1000, br.heightmm/1000, br.thicknessmm/1000)
     bpy.context.active_object.location = (float(
         br.justifyx)*br.widthmm/1000, float(br.justifyy)*br.heightmm/1000, float(br.justifyz)*br.thicknessmm/1000)
 
@@ -719,7 +726,8 @@ def renderScene(width, height, bit_diameter, passes_per_radius, make_nodes, view
     scene.render.resolution_x = x
     scene.render.resolution_y = y
     scene.render.resolution_percentage = 100
-    bpy.ops.render.render(animation=False, write_still=False, use_viewport=True, layer="", scene="")
+    bpy.ops.render.render(animation=False, write_still=False,
+                          use_viewport=True, layer="", scene="")
     if our_renderer is not None:
         nodes.remove(our_renderer)
     if our_viewer is not None:
@@ -769,7 +777,8 @@ def problemAreas(br):
 
     # it' ok, we can treat neg and positive silh separately here:
     a = br.attenuation
-    planar = nar < (nar.min()+0.0001)  # numpy.logical_or(silhxplanar,silhyplanar)#
+    # numpy.logical_or(silhxplanar,silhyplanar)#
+    planar = nar < (nar.min()+0.0001)
     # sqrt for silhouettes recovery:
     sqrarx = numpy.abs(gx)
     for iter in range(0, br.silhouette_exponent):
@@ -859,7 +868,8 @@ def relief(br):
 
     # it' ok, we can treat neg and positive silh separately here:
     a = br.attenuation
-    planar = nar < (nar.min()+0.0001)  # numpy.logical_or(silhxplanar,silhyplanar)#
+    # numpy.logical_or(silhxplanar,silhyplanar)#
+    planar = nar < (nar.min()+0.0001)
     # sqrt for silhouettes recovery:
     sqrarx = numpy.abs(gx)
     for iter in range(0, br.silhouette_exponent):
@@ -927,7 +937,8 @@ def relief(br):
             # v=(abs((cx-x)/(cx))+abs((cy-y)/(cy)))
             # return v
 
-        mask = numpy.fromfunction(filterwindow, divg.shape, cx=crow, cy=ccol)  # , curve=cur)
+        mask = numpy.fromfunction(
+            filterwindow, divg.shape, cx=crow, cy=ccol)  # , curve=cur)
         mask = numpy.sqrt(mask)
         # for x in range(mask.shape[0]):
         #	for y in range(mask.shape[1]):
@@ -970,64 +981,213 @@ def relief(br):
 
 
 class BasReliefsettings(bpy.types.PropertyGroup):
-    use_image_source: bpy.props.BoolProperty(name="Use image source", description="", default=False)
-    source_image_name: bpy.props.StringProperty(name='Image source', description='image source')
-    view_layer_name: bpy.props.StringProperty(
-        name='View layer source', description='Make a bas-relief from whatever is on this view layer')
-    bit_diameter: FloatProperty(name="Diameter of ball end in mm", description="Diameter of bit which will be used for carving",
-                                min=0.01, max=50.0, default=3.175, precision=PRECISION)
-    pass_per_radius: bpy.props.IntProperty(
-        name="Passes per radius", description="Amount of passes per radius\n(more passes, more mesh precision)", default=2, min=1, max=10)
-    widthmm: bpy.props.IntProperty(name="Desired width in mm", default=200, min=5, max=4000)
-    heightmm: bpy.props.IntProperty(name="Desired height in mm", default=150, min=5, max=4000)
-    thicknessmm: bpy.props.IntProperty(name="Thickness in mm", default=15, min=5, max=100)
+    use_image_source: BoolProperty(
+        name="Use image source",
+        description="",
+        default=False,
+    )
+    source_image_name: StringProperty(
+        name='Image source',
+        description='image source',
+    )
+    view_layer_name: StringProperty(
+        name='View layer source',
+        description='Make a bas-relief from whatever is on this view layer',
+    )
+    bit_diameter: FloatProperty(
+        name="Diameter of ball end in mm",
+        description="Diameter of bit which will be used for carving",
+        min=0.01,
+        max=50.0,
+        default=3.175,
+        precision=PRECISION,
+    )
+    pass_per_radius: IntProperty(
+        name="Passes per radius",
+        description="Amount of passes per radius\n(more passes, "
+        "more mesh precision)",
+        default=2,
+        min=1,
+        max=10,
+    )
+    widthmm: IntProperty(
+        name="Desired width in mm",
+        default=200,
+        min=5,
+        max=4000,
+    )
+    heightmm: IntProperty(
+        name="Desired height in mm",
+        default=150,
+        min=5,
+        max=4000,
+    )
+    thicknessmm: IntProperty(
+        name="Thickness in mm",
+        default=15,
+        min=5,
+        max=100,
+    )
 
-    justifyx: bpy.props.EnumProperty(name="X", items=[(
-        '1', 'Left', '', 0), ('-0.5', 'Centered', '', 1), ('-1', 'Right', '', 2)], default='-1')
-    justifyy: bpy.props.EnumProperty(name="Y", items=[(
-        '1', 'Bottom', '', 0), ('-0.5', 'Centered', '', 2), ('-1', 'Top', '', 1), ], default='-1')
-    justifyz: bpy.props.EnumProperty(name="Z", items=[(
-        '-1', 'Below 0', '', 0), ('-0.5', 'Centered', '', 2), ('1', 'Above 0', '', 1), ], default='-1')
+    justifyx: EnumProperty(
+        name="X",
+        items=[
+            ('1', 'Left', '', 0),
+            ('-0.5', 'Centered', '', 1),
+            ('-1', 'Right', '', 2)
+        ],
+        default='-1',
+    )
+    justifyy: EnumProperty(
+        name="Y",
+        items=[
+            ('1', 'Bottom', '', 0),
+            ('-0.5', 'Centered', '', 2),
+            ('-1', 'Top', '', 1),
+        ],
+        default='-1',
+    )
+    justifyz: EnumProperty(
+        name="Z",
+        items=[
+            ('-1', 'Below 0', '', 0),
+            ('-0.5', 'Centered', '', 2),
+            ('1', 'Above 0', '', 1),
+        ],
+        default='-1',
+    )
 
-    depth_exponent: FloatProperty(name="Depth exponent", description="Initial depth map is taken to this power. Higher = sharper relief",
-                                  min=0.5, max=10.0, default=1.0, precision=PRECISION)
+    depth_exponent: FloatProperty(
+        name="Depth exponent",
+        description="Initial depth map is taken to this power. Higher = "
+        "sharper relief",
+        min=0.5,
+        max=10.0,
+        default=1.0,
+        precision=PRECISION,
+    )
 
     silhouette_threshold: FloatProperty(
-        name="Silhouette threshold", description="Silhouette threshold", min=0.000001, max=1.0, default=0.003, precision=PRECISION)
-    recover_silhouettes: bpy.props.BoolProperty(
-        name="Recover silhouettes", description="", default=True)
-    silhouette_scale: FloatProperty(name="Silhouette scale", description="Silhouette scale",
-                                    min=0.000001, max=5.0, default=0.3, precision=PRECISION)
-    silhouette_exponent: bpy.props.IntProperty(
-        name="Silhouette square exponent", description="If lower, true depht distances between objects will be more visibe in the relief", default=3, min=0, max=5)
-    attenuation: FloatProperty(name="Gradient attenuation", description="Gradient attenuation",
-                               min=0.000001, max=100.0, default=1.0, precision=PRECISION)
-    min_gridsize: bpy.props.IntProperty(name="Minimum grid size", default=16, min=2, max=512)
-    smooth_iterations: bpy.props.IntProperty(name="Smooth iterations", default=1, min=1, max=64)
-    vcycle_iterations: bpy.props.IntProperty(
-        name="V-cycle iterations", description="set up higher for plananr constraint", default=2, min=1, max=128)
-    linbcg_iterations: bpy.props.IntProperty(
-        name="Linbcg iterations", description="set lower for flatter relief, and when using planar constraint", default=5, min=1, max=64)
-    use_planar: bpy.props.BoolProperty(name="Use planar constraint", description="", default=False)
-    gradient_scaling_mask_use: bpy.props.BoolProperty(
-        name="Scale gradients with mask", description="", default=False)
-    decimate_ratio: FloatProperty(name="Decimate Ratio", description="Simplify the mesh using the Decimate modifier.  The lower the value the more simplyfied",
-                                  min=0.01, max=1.0, default=0.1, precision=PRECISION)
+        name="Silhouette threshold",
+        description="Silhouette threshold",
+        min=0.000001,
+        max=1.0,
+        default=0.003,
+        precision=PRECISION,
+    )
+    recover_silhouettes: BoolProperty(
+        name="Recover silhouettes",
+        description="",
+        default=True,
+    )
+    silhouette_scale: FloatProperty(
+        name="Silhouette scale",
+        description="Silhouette scale",
+        min=0.000001,
+        max=5.0,
+        default=0.3,
+        precision=PRECISION,
+    )
+    silhouette_exponent: IntProperty(
+        name="Silhouette square exponent",
+        description="If lower, true depht distances between objects will be "
+        "more visibe in the relief",
+        default=3,
+        min=0,
+        max=5,
+    )
+    attenuation: FloatProperty(
+        name="Gradient attenuation",
+        description="Gradient attenuation",
+        min=0.000001,
+        max=100.0,
+        default=1.0,
+        precision=PRECISION,
+    )
+    min_gridsize: IntProperty(
+        name="Minimum grid size",
+        default=16,
+        min=2,
+        max=512,
+    )
+    smooth_iterations: IntProperty(
+        name="Smooth iterations",
+        default=1,
+        min=1,
+        max=64,
+    )
+    vcycle_iterations: IntProperty(
+        name="V-cycle iterations",
+        description="set up higher for plananr constraint",
+        default=2,
+        min=1,
+        max=128,
+    )
+    linbcg_iterations: IntProperty(
+        name="Linbcg iterations",
+        description="set lower for flatter relief, and when using "
+        "planar constraint",
+        default=5,
+        min=1,
+        max=64,
+    )
+    use_planar: BoolProperty(
+        name="Use planar constraint",
+        description="",
+        default=False,
+    )
+    gradient_scaling_mask_use: BoolProperty(
+        name="Scale gradients with mask",
+        description="",
+        default=False,
+    )
+    decimate_ratio: FloatProperty(
+        name="Decimate Ratio",
+        description="Simplify the mesh using the Decimate modifier. "
+        "The lower the value the more simplyfied",
+        min=0.01,
+        max=1.0,
+        default=0.1,
+        precision=PRECISION,
+    )
 
-    gradient_scaling_mask_name: bpy.props.StringProperty(
-        name='Scaling mask name', description='mask name')
-    scale_down_before_use: bpy.props.BoolProperty(
-        name="Scale down image before processing", description="", default=False)
+    gradient_scaling_mask_name: StringProperty(
+        name='Scaling mask name',
+        description='mask name',
+    )
+    scale_down_before_use: BoolProperty(
+        name="Scale down image before processing",
+        description="",
+        default=False,
+    )
     scale_down_before: FloatProperty(
-        name="Image scale", description="Image scale", min=0.025, max=1.0, default=.5, precision=PRECISION)
-    detail_enhancement_use: bpy.props.BoolProperty(
-        name="Enhance details ", description="enhance details by frequency analysis", default=False)
+        name="Image scale",
+        description="Image scale",
+        min=0.025,
+        max=1.0,
+        default=.5,
+        precision=PRECISION,
+    )
+    detail_enhancement_use: BoolProperty(
+        name="Enhance details ",
+        description="enhance details by frequency analysis",
+        default=False,
+    )
     #detail_enhancement_freq=FloatProperty(name="frequency limit", description="Image scale", min=0.025, max=1.0, default=.5, precision=PRECISION)
     detail_enhancement_amount: FloatProperty(
-        name="amount", description="Image scale", min=0.025, max=1.0, default=.5, precision=PRECISION)
+        name="amount",
+        description="Image scale",
+        min=0.025,
+        max=1.0,
+        default=.5,
+        precision=PRECISION,
+    )
 
-    advanced: bpy.props.BoolProperty(
-        name="Advanced options", description="show advanced options", default=True)
+    advanced: BoolProperty(
+        name="Advanced options",
+        description="show advanced options",
+        default=True,
+    )
 
 
 class BASRELIEF_Panel(bpy.types.Panel):
@@ -1063,7 +1223,8 @@ class BASRELIEF_Panel(bpy.types.Panel):
         if br.use_image_source:
             layout.prop_search(br, 'source_image_name', bpy.data, "images")
         else:
-            layout.prop_search(br, 'view_layer_name', bpy.context.scene, "view_layers")
+            layout.prop_search(br, 'view_layer_name',
+                               bpy.context.scene, "view_layers")
         layout.prop(br, 'depth_exponent')
         layout.label(text="Project parameters")
         layout.prop(br, 'bit_diameter')
@@ -1097,7 +1258,8 @@ class BASRELIEF_Panel(bpy.types.Panel):
         layout.prop(br, 'gradient_scaling_mask_use')
         if br.advanced:
             if br.gradient_scaling_mask_use:
-                layout.prop_search(br, 'gradient_scaling_mask_name', bpy.data, "images")
+                layout.prop_search(
+                    br, 'gradient_scaling_mask_name', bpy.data, "images")
             layout.prop(br, 'detail_enhancement_use')
             if br.detail_enhancement_use:
                 # layout.prop(br,'detail_enhancement_freq')
@@ -1179,7 +1341,9 @@ def register():
     for p in get_panels():
         bpy.utils.register_class(p)
     s = bpy.types.Scene
-    s.basreliefsettings = bpy.props.PointerProperty(type=BasReliefsettings)
+    s.basreliefsettings = PointerProperty(
+        type=BasReliefsettings,
+    )
 
 
 def unregister():

--- a/scripts/addons/cam/curvecamcreate.py
+++ b/scripts/addons/cam/curvecamcreate.py
@@ -40,22 +40,65 @@ class CamCurveHatch(bpy.types.Operator):
     bl_label = "CrossHatch curve"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    angle: bpy.props.FloatProperty(name="angle", default=0, min=-
-                                   math.pi/2, max=math.pi/2, precision=4, subtype="ANGLE")
-    distance: bpy.props.FloatProperty(name="spacing", default=0.015,
-                                      min=0, max=3.0, precision=4, unit="LENGTH")
-    offset: bpy.props.FloatProperty(name="Margin", default=0.001,
-                                    min=-1.0, max=3.0, precision=4, unit="LENGTH")
-    height: bpy.props.FloatProperty(name="Height", default=0.000,
-                                    min=-1.0, max=1.0, precision=4, unit="LENGTH")
-    amount: bpy.props.IntProperty(name="amount", default=10, min=1, max=10000)
-    hull: bpy.props.BoolProperty(name="Convex Hull", default=False)
-    contour: bpy.props.BoolProperty(name="Contour Curve", default=False)
-    contour_separate: bpy.props.BoolProperty(name="Contour separate", default=False)
-    pocket_type: EnumProperty(name='Type pocket',
-                              items=(('BOUNDS', 'makes a bounds rectangle', 'makes a bounding square'),
-                                     ('POCKET', 'Pocket', 'makes a pocket inside a closed loop')),
-                              description='Type of pocket', default='BOUNDS')
+    angle: FloatProperty(
+        name="angle",
+        default=0, min=-
+        math.pi/2,
+        max=math.pi/2,
+        precision=4,
+        subtype="ANGLE",
+    )
+    distance: FloatProperty(
+        name="spacing",
+        default=0.015,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    offset: FloatProperty(
+        name="Margin",
+        default=0.001,
+        min=-1.0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    height: FloatProperty(
+        name="Height",
+        default=0.000,
+        min=-1.0,
+        max=1.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    amount: IntProperty(
+        name="amount",
+        default=10,
+        min=1,
+        max=10000,
+    )
+    hull: BoolProperty(
+        name="Convex Hull",
+        default=False,
+    )
+    contour: BoolProperty(
+        name="Contour Curve",
+        default=False,
+    )
+    contour_separate: BoolProperty(
+        name="Contour separate",
+        default=False,
+    )
+    pocket_type: EnumProperty(
+        name='Type pocket',
+        items=(
+            ('BOUNDS', 'makes a bounds rectangle', 'makes a bounding square'),
+            ('POCKET', 'Pocket', 'makes a pocket inside a closed loop')
+        ),
+        description='Type of pocket',
+        default='BOUNDS',
+    )
 
     @classmethod
     def poll(cls, context):
@@ -103,15 +146,19 @@ class CamCurveHatch(bpy.types.Operator):
             width = maxx - minx
             centerx = (minx+maxx) / 2
             diagonal = math.hypot(width, height)
-            simple.add_bound_rectangle(minx, miny, maxx, maxy, 'crosshatch_bound')
+            simple.add_bound_rectangle(
+                minx, miny, maxx, maxy, 'crosshatch_bound')
             amount = int(2*diagonal/self.distance) + 1
 
             for x in range(amount):
                 distance = x * self.distance - diagonal
-                coords.append(((distance, diagonal + 0.5), (distance, -diagonal - 0.5)))
+                coords.append(((distance, diagonal + 0.5),
+                               (distance, -diagonal - 0.5)))
 
-            lines = MultiLineString(coords)  # create a multilinestring shapely object
-            rotated = affinity.rotate(lines, self.angle, use_radians=True)  # rotate using shapely
+            # create a multilinestring shapely object
+            lines = MultiLineString(coords)
+            rotated = affinity.rotate(
+                lines, self.angle, use_radians=True)  # rotate using shapely
             translated = affinity.translate(
                 rotated, xoff=centerx, yoff=centery)  # move using shapely
 
@@ -161,28 +208,86 @@ class CamCurvePlate(bpy.types.Operator):
     bl_label = "Sign plate"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    radius: bpy.props.FloatProperty(name="Corner Radius", default=.025,
-                                    min=0, max=0.1, precision=4, unit="LENGTH")
-    width: bpy.props.FloatProperty(name="Width of plate", default=0.3048,
-                                   min=0, max=3.0, precision=4, unit="LENGTH")
-    height: bpy.props.FloatProperty(name="Height of plate", default=0.457,
-                                    min=0, max=3.0, precision=4, unit="LENGTH")
-    hole_diameter: bpy.props.FloatProperty(name="Hole diameter", default=0.01, min=0, max=3.0, precision=4,
-                                           unit="LENGTH")
-    hole_tolerance: bpy.props.FloatProperty(name="Hole V Tolerance", default=0.005, min=0, max=3.0, precision=4,
-                                            unit="LENGTH")
-    hole_vdist: bpy.props.FloatProperty(name="Hole Vert distance", default=0.400, min=0, max=3.0, precision=4,
-                                        unit="LENGTH")
-    hole_hdist: bpy.props.FloatProperty(name="Hole horiz distance", default=0, min=0, max=3.0, precision=4,
-                                        unit="LENGTH")
-    hole_hamount: bpy.props.IntProperty(name="Hole horiz amount", default=1, min=0, max=50)
-    resolution: bpy.props.IntProperty(name="Spline resolution", default=50, min=3, max=150)
-    plate_type: EnumProperty(name='Type plate',
-                             items=(('ROUNDED', 'Rounded corner', 'Makes a rounded corner plate'),
-                                    ('COVE', 'Cove corner', 'Makes a plate with circles cut in each corner '),
-                                    ('BEVEL', 'Bevel corner', 'Makes a plate with beveled corners '),
-                                    ('OVAL', 'Elipse', 'Makes an oval plate')),
-                             description='Type of Plate', default='ROUNDED')
+    radius: FloatProperty(
+        name="Corner Radius",
+        default=.025,
+        min=0,
+        max=0.1,
+        precision=4,
+        unit="LENGTH",
+    )
+    width: FloatProperty(
+        name="Width of plate",
+        default=0.3048,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    height: FloatProperty(
+        name="Height of plate",
+        default=0.457,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    hole_diameter: FloatProperty(
+        name="Hole diameter",
+        default=0.01,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    hole_tolerance: FloatProperty(
+        name="Hole V Tolerance",
+        default=0.005,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    hole_vdist: FloatProperty(
+        name="Hole Vert distance",
+        default=0.400,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    hole_hdist: FloatProperty(
+        name="Hole horiz distance",
+        default=0,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    hole_hamount: IntProperty(
+        name="Hole horiz amount",
+        default=1,
+        min=0,
+        max=50,
+    )
+    resolution: IntProperty(
+        name="Spline resolution",
+        default=50,
+        min=3,
+        max=150,
+    )
+    plate_type: EnumProperty(
+        name='Type plate',
+        items=(
+            ('ROUNDED', 'Rounded corner', 'Makes a rounded corner plate'),
+            ('COVE', 'Cove corner',
+             'Makes a plate with circles cut in each corner '),
+            ('BEVEL', 'Bevel corner', 'Makes a plate with beveled corners '),
+            ('OVAL', 'Elipse', 'Makes an oval plate')
+        ),
+        description='Type of Plate',
+        default='ROUNDED',
+    )
 
     def draw(self, context):
         layout = self.layout
@@ -224,8 +329,10 @@ class CamCurvePlate(bpy.types.Operator):
             simple.active_name("_circ_RT")
             bpy.context.object.data.resolution_u = self.resolution
 
-            simple.select_multiple("_circ")  # select the circles for the four corners
-            utils.polygonConvexHull(context)  # perform hull operation on the four corner circles
+            # select the circles for the four corners
+            simple.select_multiple("_circ")
+            # perform hull operation on the four corner circles
+            utils.polygonConvexHull(context)
             simple.active_name("plate_base")
             simple.remove_multiple("_circ")  # remove corner circles
 
@@ -271,13 +378,15 @@ class CamCurvePlate(bpy.types.Operator):
             bpy.context.object.data.resolution_u = self.resolution
             bpy.ops.curve.simple(align='WORLD', Simple_Type='Rectangle',
                                  Simple_width=self.radius*2, Simple_length=self.radius*2,
-                                 location=(right+self.radius, bottom-self.radius, 0),
+                                 location=(right+self.radius,
+                                           bottom-self.radius, 0),
                                  rotation=(0, 0, 0.785398), outputType='POLY', use_cyclic_u=True, edit_mode=False)
             simple.active_name("_bev_RB")
             bpy.context.object.data.resolution_u = self.resolution
             bpy.ops.curve.simple(align='WORLD', Simple_Type='Rectangle',
                                  Simple_width=self.radius*2, Simple_length=self.radius*2,
-                                 location=(left-self.radius, top+self.radius, 0),
+                                 location=(left-self.radius,
+                                           top+self.radius, 0),
                                  rotation=(0, 0, 0.785398), outputType='POLY', use_cyclic_u=True, edit_mode=False)
 
             simple.active_name("_bev_LT")
@@ -285,7 +394,8 @@ class CamCurvePlate(bpy.types.Operator):
 
             bpy.ops.curve.simple(align='WORLD', Simple_Type='Rectangle',
                                  Simple_width=self.radius*2, Simple_length=self.radius*2,
-                                 location=(right+self.radius, top+self.radius, 0),
+                                 location=(right+self.radius,
+                                           top+self.radius, 0),
                                  rotation=(0, 0, 0.785398), outputType='POLY', use_cyclic_u=True, edit_mode=False)
 
             simple.active_name("_bev_RT")
@@ -329,14 +439,16 @@ class CamCurvePlate(bpy.types.Operator):
             if self.hole_hamount > 1:
                 if self.hole_hamount % 2 != 0:
                     for x in range(int((self.hole_hamount - 1) / 2)):
-                        dist = self.hole_hdist * (x + 1)  # calculate the distance from the middle
+                        # calculate the distance from the middle
+                        dist = self.hole_hdist * (x + 1)
                         simple.duplicate()
                         bpy.context.object.location[0] = dist
                         simple.duplicate()
                         bpy.context.object.location[0] = -dist
                 else:
                     for x in range(int(self.hole_hamount / 2)):
-                        dist = self.hole_hdist * x + self.hole_hdist / 2  # calculate the distance from the middle
+                        dist = self.hole_hdist * x + self.hole_hdist / \
+                            2  # calculate the distance from the middle
                         if x == 0:  # special case where the original hole only needs to move and not duplicate
                             bpy.context.object.location[0] = dist
                             simple.duplicate()
@@ -348,11 +460,13 @@ class CamCurvePlate(bpy.types.Operator):
                             bpy.context.object.location[0] = -dist
                 simple.join_multiple("plate_hole")  # join the holes together
 
-            simple.select_multiple("plate_")  # select everything starting with plate_
+            # select everything starting with plate_
+            simple.select_multiple("plate_")
 
             # Make the plate base active
             bpy.context.view_layer.objects.active = bpy.data.objects['plate_base']
-            utils.polygonBoolean(context, "DIFFERENCE")  # Remove holes from the base
+            # Remove holes from the base
+            utils.polygonBoolean(context, "DIFFERENCE")
             simple.remove_multiple("plate_")  # Remove temporary base and holes
             simple.remove_multiple("_")
 
@@ -369,18 +483,58 @@ class CamCurveFlatCone(bpy.types.Operator):
     bl_label = "Cone flat calculator"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    small_d: bpy.props.FloatProperty(
-        name="small diameter", default=.025, min=0, max=0.1, precision=4, unit="LENGTH")
-    large_d: bpy.props.FloatProperty(
-        name="large diameter", default=0.3048, min=0, max=3.0, precision=4, unit="LENGTH")
-    height: bpy.props.FloatProperty(name="Height of cone", default=0.457,
-                                    min=0, max=3.0, precision=4, unit="LENGTH")
-    tab: bpy.props.FloatProperty(name="tab witdh", default=0.01, min=0,
-                                 max=0.100, precision=4, unit="LENGTH")
-    intake: bpy.props.FloatProperty(name="intake diameter", default=0,
-                                    min=0, max=0.200, precision=4, unit="LENGTH")
-    intake_skew: bpy.props.FloatProperty(name="intake_skew", default=1, min=0.1, max=4)
-    resolution: bpy.props.IntProperty(name="Resolution", default=12, min=5, max=200)
+    small_d: FloatProperty(
+        name="small diameter",
+        default=.025,
+        min=0,
+        max=0.1,
+        precision=4,
+        unit="LENGTH",
+    )
+    large_d: FloatProperty(
+        name="large diameter",
+        default=0.3048,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    height: FloatProperty(
+        name="Height of cone",
+        default=0.457,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    tab: FloatProperty(
+        name="tab witdh",
+        default=0.01,
+        min=0,
+        max=0.100,
+        precision=4,
+        unit="LENGTH",
+    )
+    intake: FloatProperty(
+        name="intake diameter",
+        default=0,
+        min=0,
+        max=0.200,
+        precision=4,
+        unit="LENGTH",
+    )
+    intake_skew: FloatProperty(
+        name="intake_skew",
+        default=1,
+        min=0.1,
+        max=4,
+    )
+    resolution: IntProperty(
+        name="Resolution",
+        default=12,
+        min=5,
+        max=200,
+    )
 
     def execute(self, context):
         y = self.small_d / 2
@@ -426,25 +580,75 @@ class CamCurveMortise(bpy.types.Operator):
     bl_label = "Mortise"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    finger_size: bpy.props.BoolProperty(name="kurf bending only", default=False)
-    finger_size: bpy.props.FloatProperty(name="Maximum Finger Size", default=0.015, min=0.005, max=3.0, precision=4,
-                                         unit="LENGTH")
-    min_finger_size: bpy.props.FloatProperty(name="Minimum Finger Size", default=0.0025, min=0.001, max=3.0,
-                                             precision=4,
-                                             unit="LENGTH")
-    finger_tolerance: bpy.props.FloatProperty(name="Finger play room", default=0.000045, min=0, max=0.003, precision=4,
-                                              unit="LENGTH")
-    plate_thickness: bpy.props.FloatProperty(name="Drawer plate thickness", default=0.00477, min=0.001, max=3.0,
-                                             unit="LENGTH")
-    side_height: bpy.props.FloatProperty(
-        name="side height", default=0.05, min=0.001, max=3.0, unit="LENGTH")
-    flex_pocket: bpy.props.FloatProperty(
-        name="Flex pocket", default=0.004, min=0.000, max=1.0, unit="LENGTH")
-    top_bottom: bpy.props.BoolProperty(name="Side Top & bottom fingers", default=True)
-    opencurve: bpy.props.BoolProperty(name="OpenCurve", default=False)
-    adaptive: bpy.props.FloatProperty(name="Adaptive angle threshold", default=0.0, min=0.000, max=2, subtype="ANGLE",
-                                      unit="ROTATION")
-    double_adaptive: bpy.props.BoolProperty(name="Double adaptive Pockets", default=False)
+    finger_size: BoolProperty(
+        name="kurf bending only",
+        default=False,
+    )
+    finger_size: FloatProperty(
+        name="Maximum Finger Size",
+        default=0.015,
+        min=0.005,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    min_finger_size: FloatProperty(
+        name="Minimum Finger Size",
+        default=0.0025,
+        min=0.001,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    finger_tolerance: FloatProperty(
+        name="Finger play room",
+        default=0.000045,
+        min=0,
+        max=0.003,
+        precision=4,
+        unit="LENGTH",
+    )
+    plate_thickness: FloatProperty(
+        name="Drawer plate thickness",
+        default=0.00477,
+        min=0.001,
+        max=3.0,
+        unit="LENGTH",
+    )
+    side_height: FloatProperty(
+        name="side height",
+        default=0.05,
+        min=0.001,
+        max=3.0,
+        unit="LENGTH",
+    )
+    flex_pocket: FloatProperty(
+        name="Flex pocket",
+        default=0.004,
+        min=0.000,
+        max=1.0,
+        unit="LENGTH",
+    )
+    top_bottom: BoolProperty(
+        name="Side Top & bottom fingers",
+        default=True,
+    )
+    opencurve: BoolProperty(
+        name="OpenCurve",
+        default=False,
+    )
+    adaptive: FloatProperty(
+        name="Adaptive angle threshold",
+        default=0.0,
+        min=0.000,
+        max=2,
+        subtype="ANGLE",
+        unit="ROTATION",
+    )
+    double_adaptive: BoolProperty(
+        name="Double adaptive Pockets",
+        default=False,
+    )
 
     @classmethod
     def poll(cls, context):
@@ -463,7 +667,8 @@ class CamCurveMortise(bpy.types.Operator):
             coords = []
             for v in obj.data.vertices:  # extract X,Y coordinates from the vertices data
                 coords.append((v.co.x, v.co.y))
-            line = LineString(coords)  # convert coordinates to shapely LineString datastructure
+            # convert coordinates to shapely LineString datastructure
+            line = LineString(coords)
             simple.remove_multiple("-converted")
             utils.shapelyToCurve('-converted_curve', line, 0.0)
         shapes = utils.curveToShapely(o1)
@@ -518,27 +723,69 @@ class CamCurveInterlock(bpy.types.Operator):
     bl_label = "Interlock"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    finger_size: bpy.props.FloatProperty(name="Finger Size", default=0.015, min=0.005, max=3.0, precision=4,
-                                         unit="LENGTH")
-    finger_tolerance: bpy.props.FloatProperty(name="Finger play room", default=0.000045, min=0, max=0.003, precision=4,
-                                              unit="LENGTH")
-    plate_thickness: bpy.props.FloatProperty(name="Plate thickness", default=0.00477, min=0.001, max=3.0,
-                                             unit="LENGTH")
-    opencurve: bpy.props.BoolProperty(name="OpenCurve", default=False)
-    interlock_type: EnumProperty(name='Type of interlock',
-                                 items=(('TWIST', 'Twist', 'Iterlock requires 1/4 turn twist'),
-                                        ('GROOVE', 'Groove', 'Simple sliding groove'),
-                                        ('PUZZLE', 'Puzzle interlock', 'puzzle good for flat joints')),
-                                 description='Type of interlock',
-                                 default='GROOVE')
-    finger_amount: bpy.props.IntProperty(name="Finger Amount", default=2, min=1, max=100)
-    tangent_angle: bpy.props.FloatProperty(name="Tangent deviation", default=0.0, min=0.000, max=2, subtype="ANGLE",
-                                           unit="ROTATION")
-    fixed_angle: bpy.props.FloatProperty(name="fixed angle", default=0.0, min=0.000, max=2, subtype="ANGLE",
-                                         unit="ROTATION")
+    finger_size: FloatProperty(
+        name="Finger Size",
+        default=0.015,
+        min=0.005,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    finger_tolerance: FloatProperty(
+        name="Finger play room",
+        default=0.000045,
+        min=0,
+        max=0.003,
+        precision=4,
+        unit="LENGTH",
+    )
+    plate_thickness: FloatProperty(
+        name="Plate thickness",
+        default=0.00477,
+        min=0.001,
+        max=3.0,
+        unit="LENGTH",
+    )
+    opencurve: BoolProperty(
+        name="OpenCurve",
+        default=False,
+    )
+    interlock_type: EnumProperty(
+        name='Type of interlock',
+        items=(
+            ('TWIST', 'Twist', 'Iterlock requires 1/4 turn twist'),
+            ('GROOVE', 'Groove', 'Simple sliding groove'),
+            ('PUZZLE', 'Puzzle interlock', 'puzzle good for flat joints')
+        ),
+        description='Type of interlock',
+        default='GROOVE',
+    )
+    finger_amount: IntProperty(
+        name="Finger Amount",
+        default=2,
+        min=1,
+        max=100,
+    )
+    tangent_angle: FloatProperty(
+        name="Tangent deviation",
+        default=0.0,
+        min=0.000,
+        max=2,
+        subtype="ANGLE",
+        unit="ROTATION",
+    )
+    fixed_angle: FloatProperty(
+        name="fixed angle",
+        default=0.0,
+        min=0.000,
+        max=2,
+        subtype="ANGLE",
+        unit="ROTATION",
+    )
 
     def execute(self, context):
-        print(len(context.selected_objects), "selected object", context.selected_objects)
+        print(len(context.selected_objects),
+              "selected object", context.selected_objects)
         if len(context.selected_objects) > 0 and (context.active_object.type in ['CURVE', 'FONT']):
             o1 = bpy.context.active_object
 
@@ -552,7 +799,8 @@ class CamCurveInterlock(bpy.types.Operator):
                 coords = []
                 for v in obj.data.vertices:  # extract X,Y coordinates from the vertices data
                     coords.append((v.co.x, v.co.y))
-                line = LineString(coords)  # convert coordinates to shapely LineString datastructure
+                # convert coordinates to shapely LineString datastructure
+                line = LineString(coords)
                 simple.remove_multiple("-converted")
                 utils.shapelyToCurve('-converted_curve', line, 0.0)
             shapes = utils.curveToShapely(o1)
@@ -595,27 +843,90 @@ class CamCurveDrawer(bpy.types.Operator):
     bl_label = "Drawer"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    depth: bpy.props.FloatProperty(name="Drawer Depth", default=0.2,
-                                   min=0, max=1.0, precision=4, unit="LENGTH")
-    width: bpy.props.FloatProperty(name="Width of Drawer", default=0.125,
-                                   min=0, max=3.0, precision=4, unit="LENGTH")
-    height: bpy.props.FloatProperty(name="Height of drawer", default=0.07,
-                                    min=0, max=3.0, precision=4, unit="LENGTH")
-    finger_size: bpy.props.FloatProperty(name="Maximum Finger Size", default=0.015, min=0.005, max=3.0, precision=4,
-                                         unit="LENGTH")
-    finger_tolerance: bpy.props.FloatProperty(name="Finger play room", default=0.000045, min=0, max=0.003, precision=4,
-                                              unit="LENGTH")
-    finger_inset: bpy.props.FloatProperty(name="Finger inset", default=0.0, min=0.0, max=0.01, precision=4,
-                                          unit="LENGTH")
-    drawer_plate_thickness: bpy.props.FloatProperty(name="Drawer plate thickness", default=0.00477, min=0.001, max=3.0,
-                                                    precision=4, unit="LENGTH")
-    drawer_hole_diameter: bpy.props.FloatProperty(name="Drawer hole diameter", default=0.02, min=0.00001, max=0.5,
-                                                  precision=4, unit="LENGTH")
-    drawer_hole_offset: bpy.props.FloatProperty(name="Drawer hole offset", default=0.0, min=-0.5, max=0.5, precision=4,
-                                                unit="LENGTH")
-    overcut: bpy.props.BoolProperty(name="Add overcut", default=False)
-    overcut_diameter: bpy.props.FloatProperty(name="Overcut toool Diameter", default=0.003175, min=-0.001, max=0.5,
-                                              precision=4, unit="LENGTH")
+    depth: FloatProperty(
+        name="Drawer Depth",
+        default=0.2,
+        min=0,
+        max=1.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    width: FloatProperty(
+        name="Width of Drawer",
+        default=0.125,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    height: FloatProperty(
+        name="Height of drawer",
+        default=0.07,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    finger_size: FloatProperty(
+        name="Maximum Finger Size",
+        default=0.015,
+        min=0.005,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    finger_tolerance: FloatProperty(
+        name="Finger play room",
+        default=0.000045,
+        min=0,
+        max=0.003,
+        precision=4,
+        unit="LENGTH",
+    )
+    finger_inset: FloatProperty(
+        name="Finger inset",
+        default=0.0,
+        min=0.0,
+        max=0.01,
+        precision=4,
+        unit="LENGTH",
+    )
+    drawer_plate_thickness: FloatProperty(
+        name="Drawer plate thickness",
+        default=0.00477,
+        min=0.001,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    drawer_hole_diameter: FloatProperty(
+        name="Drawer hole diameter",
+        default=0.02,
+        min=0.00001,
+        max=0.5,
+        precision=4,
+        unit="LENGTH",
+    )
+    drawer_hole_offset: FloatProperty(
+        name="Drawer hole offset",
+        default=0.0,
+        min=-0.5,
+        max=0.5,
+        precision=4,
+        unit="LENGTH",
+    )
+    overcut: BoolProperty(
+        name="Add overcut",
+        default=False,
+    )
+    overcut_diameter: FloatProperty(
+        name="Overcut toool Diameter",
+        default=0.003175,
+        min=-0.001,
+        max=0.5,
+        precision=4,
+        unit="LENGTH",
+    )
 
     def draw(self, context):
         layout = self.layout
@@ -633,9 +944,11 @@ class CamCurveDrawer(bpy.types.Operator):
             layout.prop(self, 'overcut_diameter')
 
     def execute(self, context):
-        height_finger_amt = int(joinery.finger_amount(self.height, self.finger_size))
+        height_finger_amt = int(joinery.finger_amount(
+            self.height, self.finger_size))
         height_finger = (self.height + 0.0004) / height_finger_amt
-        width_finger_amt = int(joinery.finger_amount(self.width, self.finger_size))
+        width_finger_amt = int(joinery.finger_amount(
+            self.width, self.finger_size))
         width_finger = (self.width - self.finger_size) / width_finger_amt
 
         # create base
@@ -681,14 +994,16 @@ class CamCurveDrawer(bpy.types.Operator):
 
         #   place back and front side by side
         simple.make_active('drawer_front')
-        bpy.ops.transform.transform(mode='TRANSLATION', value=(0.0, 2 * self.height, 0.0, 0.0))
+        bpy.ops.transform.transform(
+            mode='TRANSLATION', value=(0.0, 2 * self.height, 0.0, 0.0))
         simple.make_active('drawer_back')
 
         bpy.ops.transform.transform(mode='TRANSLATION', value=(
             self.width + 0.01, 2 * self.height, 0.0, 0.0))
         #   make side
 
-        finger_pair = joinery.finger_pair("_vfb", self.depth - self.drawer_plate_thickness, 0)
+        finger_pair = joinery.finger_pair(
+            "_vfb", self.depth - self.drawer_plate_thickness, 0)
         simple.make_active('_side')
         finger_pair.select_set(True)
         fronth.select_set(True)
@@ -703,7 +1018,8 @@ class CamCurveDrawer(bpy.types.Operator):
         bpy.ops.object.duplicate_move(OBJECT_OT_duplicate={"linked": False, "mode": 'TRANSLATION'},
                                       TRANSFORM_OT_translate={"value": (0, -self.drawer_plate_thickness / 2, 0.0)})
         simple.active_name("_wfb0")
-        joinery.finger_pair("_wfb0", 0, self.depth - self.drawer_plate_thickness)
+        joinery.finger_pair("_wfb0", 0, self.depth -
+                            self.drawer_plate_thickness)
         simple.active_name('_bot_fingers')
 
         simple.difference('_bot', '_bottom')
@@ -741,81 +1057,219 @@ class CamCurvePuzzle(bpy.types.Operator):
     bl_label = "Puzzle joints"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    diameter: bpy.props.FloatProperty(name="tool diameter", default=0.003175, min=0.001, max=3.0, precision=4,
-                                      unit="LENGTH")
-    finger_tolerance: bpy.props.FloatProperty(name="Finger play room", default=0.00005, min=0, max=0.003, precision=4,
-                                              unit="LENGTH")
-    finger_amount: bpy.props.IntProperty(name="Finger Amount", default=1, min=0, max=100)
-    stem_size: bpy.props.IntProperty(name="size of the stem", default=2, min=1, max=200)
-    width: bpy.props.FloatProperty(name="Width", default=0.100, min=0.005, max=3.0, precision=4,
-                                   unit="LENGTH")
-    height: bpy.props.FloatProperty(name="height or thickness", default=0.025, min=0.005, max=3.0, precision=4,
-                                    unit="LENGTH")
+    diameter: FloatProperty(
+        name="tool diameter",
+        default=0.003175,
+        min=0.001,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    finger_tolerance: FloatProperty(
+        name="Finger play room",
+        default=0.00005,
+        min=0,
+        max=0.003,
+        precision=4,
+        unit="LENGTH",
+    )
+    finger_amount: IntProperty(
+        name="Finger Amount",
+        default=1,
+        min=0,
+        max=100,
+    )
+    stem_size: IntProperty(
+        name="size of the stem",
+        default=2,
+        min=1,
+        max=200,
+    )
+    width: FloatProperty(
+        name="Width",
+        default=0.100,
+        min=0.005,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    height: FloatProperty(
+        name="height or thickness",
+        default=0.025,
+        min=0.005,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
 
-    angle: bpy.props.FloatProperty(name="angle A", default=math.pi/4, min=-10, max=10, subtype="ANGLE",
-                                   unit="ROTATION")
-    angleb: bpy.props.FloatProperty(name="angle B", default=math.pi/4, min=-10, max=10, subtype="ANGLE",
-                                    unit="ROTATION")
+    angle: FloatProperty(
+        name="angle A",
+        default=math.pi/4,
+        min=-10,
+        max=10,
+        subtype="ANGLE",
+        unit="ROTATION",
+    )
+    angleb: FloatProperty(
+        name="angle B",
+        default=math.pi/4,
+        min=-10,
+        max=10,
+        subtype="ANGLE",
+        unit="ROTATION",
+    )
 
-    radius: bpy.props.FloatProperty(name="Arc Radius", default=0.025, min=0.005, max=5, precision=4,
-                                    unit="LENGTH")
+    radius: FloatProperty(
+        name="Arc Radius",
+        default=0.025,
+        min=0.005,
+        max=5,
+        precision=4,
+        unit="LENGTH",
+    )
 
-    interlock_type: EnumProperty(name='Type of shape',
-                                 items=(('JOINT', 'Joint', 'Puzzle Joint interlock'),
-                                        ('BAR', 'Bar', 'Bar interlock'),
-                                        ('ARC', 'Arc', 'Arc interlock'),
-                                        ('MULTIANGLE', 'Multi angle', 'Multi angle joint'),
-                                        ('CURVEBAR', 'Arc Bar', 'Arc Bar interlock'),
-                                        ('CURVEBARCURVE', 'Arc Bar Arc', 'Arc Bar Arc interlock'),
-                                        ('CURVET', 'T curve', 'T curve interlock'),
-                                        ('T', 'T Bar', 'T Bar interlock'),
-                                        ('CORNER', 'Corner Bar', 'Corner Bar interlock'),
-                                        ('TILE', 'Tile', 'Tile interlock'),
-                                        ('OPENCURVE', 'Open Curve', 'Corner Bar interlock')),
-                                 description='Type of interlock',
-                                 default='CURVET')
-    gender: EnumProperty(name='Type gender',
-                         items=(('MF', 'Male-Receptacle', 'Male and receptacle'),
-                                ('F', 'Receptacle only', 'Receptacle'),
-                                ('M', 'Male only', 'Male')),
-                         description='Type of interlock',
-                         default='MF')
-    base_gender: EnumProperty(name='Base gender',
-                              items=(('MF', 'Male - Receptacle', 'Male - Receptacle'),
-                                     ('F', 'Receptacle', 'Receptacle'),
-                                     ('M', 'Male', 'Male')),
-                              description='Type of interlock',
-                              default='M')
-    multiangle_gender: EnumProperty(name='Multiangle gender',
-                                    items=(('MMF', 'Male Male Receptacle', 'M M F'),
-                                           ('MFF', 'Male Receptacle Receptacle', 'M F F')),
-                                    description='Type of interlock',
-                                    default='MFF')
+    interlock_type: EnumProperty(
+        name='Type of shape',
+        items=(
+            ('JOINT', 'Joint', 'Puzzle Joint interlock'),
+            ('BAR', 'Bar', 'Bar interlock'),
+            ('ARC', 'Arc', 'Arc interlock'),
+            ('MULTIANGLE', 'Multi angle', 'Multi angle joint'),
+            ('CURVEBAR', 'Arc Bar', 'Arc Bar interlock'),
+            ('CURVEBARCURVE', 'Arc Bar Arc', 'Arc Bar Arc interlock'),
+            ('CURVET', 'T curve', 'T curve interlock'),
+            ('T', 'T Bar', 'T Bar interlock'),
+            ('CORNER', 'Corner Bar', 'Corner Bar interlock'),
+            ('TILE', 'Tile', 'Tile interlock'),
+            ('OPENCURVE', 'Open Curve', 'Corner Bar interlock')
+        ),
+        description='Type of interlock',
+        default='CURVET',
+    )
+    gender: EnumProperty(
+        name='Type gender',
+        items=(
+            ('MF', 'Male-Receptacle', 'Male and receptacle'),
+            ('F', 'Receptacle only', 'Receptacle'),
+            ('M', 'Male only', 'Male')
+        ),
+        description='Type of interlock',
+        default='MF',
+    )
+    base_gender: EnumProperty(
+        name='Base gender',
+        items=(
+            ('MF', 'Male - Receptacle', 'Male - Receptacle'),
+            ('F', 'Receptacle', 'Receptacle'),
+            ('M', 'Male', 'Male')
+        ),
+        description='Type of interlock',
+        default='M',
+    )
+    multiangle_gender: EnumProperty(
+        name='Multiangle gender',
+        items=(
+            ('MMF', 'Male Male Receptacle', 'M M F'),
+            ('MFF', 'Male Receptacle Receptacle', 'M F F')
+        ),
+        description='Type of interlock',
+        default='MFF',
+    )
 
-    mitre: bpy.props.BoolProperty(name="Add Mitres", default=False)
+    mitre: BoolProperty(
+        name="Add Mitres",
+        default=False,
+    )
 
-    twist_lock: bpy.props.BoolProperty(name="Add TwistLock", default=False)
-    twist_thick: bpy.props.FloatProperty(name="Twist Thickness", default=0.0047, min=0.001, max=3.0, precision=4,
-                                         unit="LENGTH")
-    twist_percent: bpy.props.FloatProperty(
-        name="Twist neck", default=0.3, min=0.1, max=0.9, precision=4)
-    twist_keep: bpy.props.BoolProperty(name="keep Twist holes", default=False)
-    twist_line: bpy.props.BoolProperty(name="Add Twist to bar", default=False)
-    twist_line_amount: bpy.props.IntProperty(name="amount of separators", default=2, min=1, max=600)
-    twist_separator: bpy.props.BoolProperty(name="Add Twist separator", default=False)
-    twist_separator_amount: bpy.props.IntProperty(
-        name="amount of separators", default=2, min=2, max=600)
-    twist_separator_spacing: bpy.props.FloatProperty(name="Separator spacing", default=0.025, min=-0.004, max=1.0,
-                                                     precision=4, unit="LENGTH")
-    twist_separator_edge_distance: bpy.props.FloatProperty(name="Separator edge distance", default=0.01, min=0.0005,
-                                                           max=0.1, precision=4, unit="LENGTH")
-    tile_x_amount: bpy.props.IntProperty(name="amount of x fingers", default=2, min=1, max=600)
-    tile_y_amount: bpy.props.IntProperty(name="amount of y fingers", default=2, min=1, max=600)
-    interlock_amount: bpy.props.IntProperty(
-        name="Interlock amount on curve", default=2, min=0, max=200)
-    overcut: bpy.props.BoolProperty(name="Add overcut", default=False)
-    overcut_diameter: bpy.props.FloatProperty(name="Overcut toool Diameter", default=0.003175, min=-0.001, max=0.5,
-                                              precision=4, unit="LENGTH")
+    twist_lock: BoolProperty(
+        name="Add TwistLock",
+        default=False,
+    )
+    twist_thick: FloatProperty(
+        name="Twist Thickness",
+        default=0.0047,
+        min=0.001,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    twist_percent: FloatProperty(
+        name="Twist neck",
+        default=0.3,
+        min=0.1,
+        max=0.9,
+        precision=4,
+    )
+    twist_keep: BoolProperty(
+        name="keep Twist holes",
+        default=False,
+    )
+    twist_line: BoolProperty(
+        name="Add Twist to bar",
+        default=False,
+    )
+    twist_line_amount: IntProperty(
+        name="amount of separators",
+        default=2,
+        min=1,
+        max=600,
+    )
+    twist_separator: BoolProperty(
+        name="Add Twist separator",
+        default=False,
+    )
+    twist_separator_amount: IntProperty(
+        name="amount of separators",
+        default=2,
+        min=2,
+        max=600,
+    )
+    twist_separator_spacing: FloatProperty(
+        name="Separator spacing",
+        default=0.025,
+        min=-0.004,
+        max=1.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    twist_separator_edge_distance: FloatProperty(
+        name="Separator edge distance",
+        default=0.01,
+        min=0.0005,
+        max=0.1,
+        precision=4,
+        unit="LENGTH",
+    )
+    tile_x_amount: IntProperty(
+        name="amount of x fingers",
+        default=2,
+        min=1,
+        max=600,
+    )
+    tile_y_amount: IntProperty(
+        name="amount of y fingers",
+        default=2,
+        min=1,
+        max=600,
+    )
+    interlock_amount: IntProperty(
+        name="Interlock amount on curve",
+        default=2,
+        min=0,
+        max=200,
+    )
+    overcut: BoolProperty(
+        name="Add overcut",
+        default=False,
+    )
+    overcut_diameter: FloatProperty(
+        name="Overcut toool Diameter",
+        default=0.003175,
+        min=-0.001,
+        max=0.5,
+        precision=4,
+        unit="LENGTH",
+    )
 
     def draw(self, context):
         layout = self.layout
@@ -852,7 +1306,7 @@ class CamCurvePuzzle(bpy.types.Operator):
         if self.interlock_type == 'BAR':
             layout.prop(self, 'mitre')
 
-        if self.interlock_type in ["ARC", "CURVEBARCURVE", "CURVEBAR", "MULTIANGLE", 'CURVET']  \
+        if self.interlock_type in ["ARC", "CURVEBARCURVE", "CURVEBAR", "MULTIANGLE", 'CURVET'] \
                 or (self.interlock_type == 'BAR' and self.mitre):
             if self.interlock_type == 'MULTIANGLE':
                 layout.prop(self, 'multiangle_gender')
@@ -878,7 +1332,8 @@ class CamCurvePuzzle(bpy.types.Operator):
 
     def execute(self, context):
         curve_detected = False
-        print(len(context.selected_objects), "selected object", context.selected_objects)
+        print(len(context.selected_objects),
+              "selected object", context.selected_objects)
         if len(context.selected_objects) > 0 and context.active_object.type == 'CURVE':
             curve_detected = True
             # bpy.context.object.data.resolution_u = 60
@@ -892,11 +1347,13 @@ class CamCurvePuzzle(bpy.types.Operator):
             for v in obj.data.vertices:  # extract X,Y coordinates from the vertices data
                 coords.append((v.co.x, v.co.y))
             simple.remove_multiple('_tmp')
-            line = LineString(coords)  # convert coordinates to shapely LineString datastructure
+            # convert coordinates to shapely LineString datastructure
+            line = LineString(coords)
             simple.remove_multiple("_")
 
         if self.interlock_type == 'FINGER':
-            puzzle_joinery.finger(self.diameter, self.finger_tolerance, stem=self.stem_size)
+            puzzle_joinery.finger(
+                self.diameter, self.finger_tolerance, stem=self.stem_size)
             simple.rename('_puzzle', 'receptacle')
             puzzle_joinery.finger(self.diameter, 0, stem=self.stem_size)
             simple.rename('_puzzle', 'finger')
@@ -995,34 +1452,97 @@ class CamCurveGear(bpy.types.Operator):
     bl_label = "Gears"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    tooth_spacing: bpy.props.FloatProperty(name="distance per tooth", default=0.010, min=0.001, max=1.0, precision=4,
-                                           unit="LENGTH")
-    tooth_amount: bpy.props.IntProperty(name="Amount of teeth", default=7, min=4)
+    tooth_spacing: FloatProperty(
+        name="distance per tooth",
+        default=0.010,
+        min=0.001,
+        max=1.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    tooth_amount: IntProperty(
+        name="Amount of teeth",
+        default=7,
+        min=4,
+    )
 
-    spoke_amount: bpy.props.IntProperty(name="Amount of spokes", default=4, min=0)
+    spoke_amount: IntProperty(
+        name="Amount of spokes",
+        default=4,
+        min=0,
+    )
 
-    hole_diameter: bpy.props.FloatProperty(name="Hole diameter", default=0.003175, min=0, max=3.0, precision=4,
-                                           unit="LENGTH")
-    rim_size: bpy.props.FloatProperty(name="Rim size", default=0.003175, min=0, max=3.0, precision=4,
-                                           unit="LENGTH")
-    hub_diameter: bpy.props.FloatProperty(name="Hub diameter", default=0.005, min=0, max=3.0, precision=4,
-                                          unit="LENGTH")
-    pressure_angle: bpy.props.FloatProperty(name="Pressure Angle", default=math.radians(20), min=0.001, max=math.pi/2,
-                                            precision=4,
-                                            subtype="ANGLE",
-                                            unit="ROTATION")
-    clearance: bpy.props.FloatProperty(name="Clearance", default=0.00, min=0, max=0.1, precision=4,
-                                       unit="LENGTH")
-    backlash: bpy.props.FloatProperty(name="Backlash", default=0.0, min=0.0, max=0.1, precision=4,
-                                      unit="LENGTH")
-    rack_height: bpy.props.FloatProperty(name="Rack Height", default=0.012, min=0.001, max=1, precision=4,
-                                         unit="LENGTH")
-    rack_tooth_per_hole: bpy.props.IntProperty(name="teeth per mounting hole", default=7, min=2)
-    gear_type: EnumProperty(name='Type of gear',
-                            items=(('PINION', 'Pinion', 'circular gear'),
-                                   ('RACK', 'Rack', 'Straight Rack')),
-                            description='Type of gear',
-                            default='PINION')
+    hole_diameter: FloatProperty(
+        name="Hole diameter",
+        default=0.003175,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    rim_size: FloatProperty(
+        name="Rim size",
+        default=0.003175,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    hub_diameter: FloatProperty(
+        name="Hub diameter",
+        default=0.005,
+        min=0,
+        max=3.0,
+        precision=4,
+        unit="LENGTH",
+    )
+    pressure_angle: FloatProperty(
+        name="Pressure Angle",
+        default=math.radians(20),
+        min=0.001,
+        max=math.pi/2,
+        precision=4,
+        subtype="ANGLE",
+        unit="ROTATION",
+    )
+    clearance: FloatProperty(
+        name="Clearance",
+        default=0.00,
+        min=0,
+        max=0.1,
+        precision=4,
+        unit="LENGTH",
+    )
+    backlash: FloatProperty(
+        name="Backlash",
+        default=0.0,
+        min=0.0,
+        max=0.1,
+        precision=4,
+        unit="LENGTH",
+    )
+    rack_height: FloatProperty(
+        name="Rack Height",
+        default=0.012,
+        min=0.001,
+        max=1,
+        precision=4,
+        unit="LENGTH",
+    )
+    rack_tooth_per_hole: IntProperty(
+        name="teeth per mounting hole",
+        default=7,
+        min=2,
+    )
+    gear_type: EnumProperty(
+        name='Type of gear',
+        items=(
+            ('PINION', 'Pinion', 'circular gear'),
+            ('RACK', 'Rack', 'Straight Rack')
+        ),
+        description='Type of gear',
+        default='PINION',
+    )
 
     def draw(self, context):
         layout = self.layout

--- a/scripts/addons/cam/curvecamequation.py
+++ b/scripts/addons/cam/curvecamequation.py
@@ -35,36 +35,111 @@ class CamSineCurve(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     #    zstring: StringProperty(name="Z equation", description="Equation for z=F(u,v)", default="0.05*sin(2*pi*4*t)" )
-    axis: bpy.props.EnumProperty(name="displacement axis", items=(
-        ('XY', 'Y to displace X axis', 'Y constant; X sine displacement'),
-        ('YX', 'X to displace Y axis', 'X constant; Y sine displacement'),
-        ('ZX', 'X to displace Z axis', 'X constant; Y sine displacement'),
-        ('ZY', 'Y to displace Z axis', 'X constant; Y sine displacement')), default='ZX')
-    wave: bpy.props.EnumProperty(name="Wave", items=(
-        ('sine', 'Sine Wave', 'Sine Wave'),
-        ('triangle', 'Triangle Wave', 'triangle wave'),
-        ('cycloid', 'Cycloid', 'Sine wave rectification'),
-        ('invcycloid', 'Inverse Cycloid', 'Sine wave rectification')), default='sine')
-    amplitude: bpy.props.FloatProperty(
-        name="Amplitude", default=.01, min=0, max=10, precision=4, unit="LENGTH")
-    period: bpy.props.FloatProperty(name="Period", default=.5,
-                                    min=0.001, max=100, precision=4, unit="LENGTH")
-    beatperiod: bpy.props.FloatProperty(name="Beat Period offset", default=0.0, min=0.0, max=100, precision=4,
-                                        unit="LENGTH")
-    shift: bpy.props.FloatProperty(name="phase shift", default=0,
-                                   min=-360, max=360, precision=4, unit="ROTATION")
-    offset: bpy.props.FloatProperty(name="offset", default=0, min=-
-                                    1.0, max=1, precision=4, unit="LENGTH")
-    iteration: bpy.props.IntProperty(name="iteration", default=100, min=50, max=2000)
-    maxt: bpy.props.FloatProperty(name="Wave ends at x", default=0.5,
-                                  min=-3.0, max=3, precision=4, unit="LENGTH")
-    mint: bpy.props.FloatProperty(name="Wave starts at x", default=0,
-                                  min=-3.0, max=3, precision=4, unit="LENGTH")
-    wave_distance: bpy.props.FloatProperty(name="distance between multiple waves", default=0.0, min=0.0, max=100,
-                                           precision=4, unit="LENGTH")
-    wave_angle_offset: bpy.props.FloatProperty(name="angle offset for multiple waves", default=math.pi/2,
-                                               min=-200*math.pi, max=200*math.pi, precision=4, unit="ROTATION")
-    wave_amount: bpy.props.IntProperty(name="amount of multiple waves", default=1, min=1, max=2000)
+    axis: EnumProperty(
+        name="displacement axis",
+        items=(
+            ('XY', 'Y to displace X axis', 'Y constant; X sine displacement'),
+            ('YX', 'X to displace Y axis', 'X constant; Y sine displacement'),
+            ('ZX', 'X to displace Z axis', 'X constant; Y sine displacement'),
+            ('ZY', 'Y to displace Z axis', 'X constant; Y sine displacement')
+        ),
+        default='ZX',
+    )
+    wave: EnumProperty(
+        name="Wave",
+        items=(
+            ('sine', 'Sine Wave', 'Sine Wave'),
+            ('triangle', 'Triangle Wave', 'triangle wave'),
+            ('cycloid', 'Cycloid', 'Sine wave rectification'),
+            ('invcycloid', 'Inverse Cycloid', 'Sine wave rectification')
+        ),
+        default='sine',
+    )
+    amplitude: FloatProperty(
+        name="Amplitude",
+        default=.01,
+        min=0,
+        max=10,
+        precision=4,
+        unit="LENGTH",
+    )
+    period: FloatProperty(
+        name="Period",
+        default=.5,
+        min=0.001,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    beatperiod: FloatProperty(
+        name="Beat Period offset",
+        default=0.0,
+        min=0.0,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    shift: FloatProperty(
+        name="phase shift",
+        default=0,
+        min=-360,
+        max=360,
+        precision=4,
+        unit="ROTATION",
+    )
+    offset: FloatProperty(
+        name="offset",
+        default=0,
+        min=-
+        1.0,
+        max=1,
+        precision=4,
+        unit="LENGTH",
+    )
+    iteration: IntProperty(
+        name="iteration",
+        default=100,
+        min=50,
+        max=2000,
+    )
+    maxt: FloatProperty(
+        name="Wave ends at x",
+        default=0.5,
+        min=-3.0,
+        max=3,
+        precision=4,
+        unit="LENGTH",
+    )
+    mint: FloatProperty(
+        name="Wave starts at x",
+        default=0,
+        min=-3.0,
+        max=3,
+        precision=4,
+        unit="LENGTH",
+    )
+    wave_distance: FloatProperty(
+        name="distance between multiple waves",
+        default=0.0,
+        min=0.0,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    wave_angle_offset: FloatProperty(
+        name="angle offset for multiple waves",
+        default=math.pi/2,
+        min=-200*math.pi,
+        max=200*math.pi,
+        precision=4,
+        unit="ROTATION",
+    )
+    wave_amount: IntProperty(
+        name="amount of multiple waves",
+        default=1,
+        min=1,
+        max=2000,
+    )
 
     def execute(self, context):
 
@@ -79,7 +154,8 @@ class CamSineCurve(bpy.types.Operator):
             zstring = str(round(self.offset, 6)) + \
                 "+(" + str(triangle(80, self.period, self.amplitude))+")"
             if self.beatperiod != 0:
-                zstring += '+' + str(triangle(80, self.period+self.beatperiod, self.amplitude))
+                zstring += '+' + \
+                    str(triangle(80, self.period+self.beatperiod, self.amplitude))
         elif self.wave == 'cycloid':
             zstring = "abs("+ssine(self.amplitude, self.period,
                                    dc_offset=self.offset, phase_shift=self.shift)+")"
@@ -116,39 +192,109 @@ class CamLissajousCurve(bpy.types.Operator):
     bl_label = "Create Lissajous figure"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    amplitude_A: bpy.props.FloatProperty(
-        name="Amplitude A", default=.1, min=0, max=100, precision=4, unit="LENGTH")
-    waveA: bpy.props.EnumProperty(name="Wave X", items=(
-        ('sine', 'Sine Wave', 'Sine Wave'),
-        ('triangle', 'Triangle Wave', 'triangle wave')), default='sine')
+    amplitude_A: FloatProperty(
+        name="Amplitude A",
+        default=.1,
+        min=0,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    waveA: EnumProperty(
+        name="Wave X",
+        items=(
+            ('sine', 'Sine Wave', 'Sine Wave'),
+            ('triangle', 'Triangle Wave', 'triangle wave')
+        ),
+        default='sine',
+    )
 
-    amplitude_B: bpy.props.FloatProperty(
-        name="Amplitude B", default=.1, min=0, max=100, precision=4, unit="LENGTH")
-    waveB: bpy.props.EnumProperty(name="Wave Y", items=(
-        ('sine', 'Sine Wave', 'Sine Wave'),
-        ('triangle', 'Triangle Wave', 'triangle wave')), default='sine')
-    period_A: bpy.props.FloatProperty(name="Period A", default=1.1,
-                                      min=0.001, max=100, precision=4, unit="LENGTH")
-    period_B: bpy.props.FloatProperty(name="Period B", default=1.0,
-                                      min=0.001, max=100, precision=4, unit="LENGTH")
-    period_Z: bpy.props.FloatProperty(name="Period Z", default=1.0,
-                                      min=0.001, max=100, precision=4, unit="LENGTH")
-    amplitude_Z: bpy.props.FloatProperty(
-        name="Amplitude Z", default=0.0, min=0, max=100, precision=4, unit="LENGTH")
-    shift: bpy.props.FloatProperty(name="phase shift", default=0,
-                                   min=-360, max=360, precision=4, unit="ROTATION")
+    amplitude_B: FloatProperty(
+        name="Amplitude B",
+        default=.1,
+        min=0,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    waveB: EnumProperty(
+        name="Wave Y",
+        items=(
+            ('sine', 'Sine Wave', 'Sine Wave'),
+            ('triangle', 'Triangle Wave', 'triangle wave')
+        ),
+        default='sine',
+    )
+    period_A: FloatProperty(
+        name="Period A",
+        default=1.1,
+        min=0.001,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    period_B: FloatProperty(
+        name="Period B",
+        default=1.0,
+        min=0.001,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    period_Z: FloatProperty(
+        name="Period Z",
+        default=1.0,
+        min=0.001,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    amplitude_Z: FloatProperty(
+        name="Amplitude Z",
+        default=0.0,
+        min=0,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    shift: FloatProperty(
+        name="phase shift",
+        default=0,
+        min=-360,
+        max=360,
+        precision=4,
+        unit="ROTATION",
+    )
 
-    iteration: bpy.props.IntProperty(name="iteration", default=500, min=50, max=10000)
-    maxt: bpy.props.FloatProperty(name="Wave ends at x", default=11,
-                                  min=-3.0, max=1000000, precision=4, unit="LENGTH")
-    mint: bpy.props.FloatProperty(name="Wave starts at x", default=0,
-                                  min=-10.0, max=3, precision=4, unit="LENGTH")
+    iteration: IntProperty(
+        name="iteration",
+        default=500,
+        min=50,
+        max=10000,
+    )
+    maxt: FloatProperty(
+        name="Wave ends at x",
+        default=11,
+        min=-3.0,
+        max=1000000,
+        precision=4,
+        unit="LENGTH",
+    )
+    mint: FloatProperty(
+        name="Wave starts at x",
+        default=0,
+        min=-10.0,
+        max=3,
+        precision=4,
+        unit="LENGTH",
+    )
 
     def execute(self, context):
         # x=Asin(at+delta ),y=Bsin(bt)
 
         if self.waveA == 'sine':
-            xstring = ssine(self.amplitude_A, self.period_A, phase_shift=self.shift)
+            xstring = ssine(self.amplitude_A, self.period_A,
+                            phase_shift=self.shift)
         elif self.waveA == 'triangle':
             xstring = str(triangle(100, self.period_A, self.amplitude_A))
 
@@ -183,16 +329,44 @@ class CamHypotrochoidCurve(bpy.types.Operator):
     bl_label = "Create Spirograph type figure"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    typecurve: bpy.props.EnumProperty(name="type of curve", items=(
-        ('hypo', 'Hypotrochoid', 'inside ring'), ('epi', 'Epicycloid', 'outside inner ring')))
-    R: bpy.props.FloatProperty(name="Big circle radius", default=0.25,
-                               min=0.001, max=100, precision=4, unit="LENGTH")
-    r: bpy.props.FloatProperty(name="Small circle radius", default=0.18, min=0.0001, max=100, precision=4,
-                               unit="LENGTH")
-    d: bpy.props.FloatProperty(name="distance from center of interior circle", default=0.050, min=0, max=100,
-                               precision=4, unit="LENGTH")
-    dip: bpy.props.FloatProperty(name="variable depth from center",
-                                 default=0.00, min=-100, max=100, precision=4)
+    typecurve: EnumProperty(
+        name="type of curve",
+        items=(
+            ('hypo', 'Hypotrochoid', 'inside ring'),
+            ('epi', 'Epicycloid', 'outside inner ring')
+        ),
+    )
+    R: FloatProperty(
+        name="Big circle radius",
+        default=0.25,
+        min=0.001,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    r: FloatProperty(
+        name="Small circle radius",
+        default=0.18,
+        min=0.0001,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    d: FloatProperty(
+        name="distance from center of interior circle",
+        default=0.050,
+        min=0,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    dip: FloatProperty(
+        name="variable depth from center",
+        default=0.00,
+        min=-100,
+        max=100,
+        precision=4,
+    )
 
     def execute(self, context):
         r = round(self.r, 6)
@@ -202,14 +376,19 @@ class CamHypotrochoidCurve(bpy.types.Operator):
         Rpr = round(R + r, 6)  # R +r
         Rpror = round(Rpr / r, 6)  # (R+r)/r
         Rmror = round(Rmr / r, 6)  # (R-r)/r
-        maxangle = 2 * math.pi * ((np.lcm(round(self.R * 1000), round(self.r * 1000)) / (R * 1000)))
+        maxangle = 2 * math.pi * \
+            ((np.lcm(round(self.R * 1000), round(self.r * 1000)) / (R * 1000)))
 
         if self.typecurve == "hypo":
-            xstring = str(Rmr) + "*cos(t)+" + str(d) + "*cos(" + str(Rmror) + "*t)"
-            ystring = str(Rmr) + "*sin(t)-" + str(d) + "*sin(" + str(Rmror) + "*t)"
+            xstring = str(Rmr) + "*cos(t)+" + str(d) + \
+                "*cos(" + str(Rmror) + "*t)"
+            ystring = str(Rmr) + "*sin(t)-" + str(d) + \
+                "*sin(" + str(Rmror) + "*t)"
         else:
-            xstring = str(Rpr) + "*cos(t)-" + str(d) + "*cos(" + str(Rpror) + "*t)"
-            ystring = str(Rpr) + "*sin(t)-" + str(d) + "*sin(" + str(Rpror) + "*t)"
+            xstring = str(Rpr) + "*cos(t)-" + str(d) + \
+                "*cos(" + str(Rpror) + "*t)"
+            ystring = str(Rpr) + "*sin(t)-" + str(d) + \
+                "*sin(" + str(Rpror) + "*t)"
 
         zstring = '(' + str(round(self.dip, 6)) + \
             '*(sqrt(((' + xstring + ')**2)+((' + ystring + ')**2))))'
@@ -244,16 +423,44 @@ class CamCustomCurve(bpy.types.Operator):
     bl_label = "Create custom curve"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    xstring: StringProperty(name="X equation", description="Equation x=F(t)", default="t")
-    ystring: StringProperty(name="Y equation", description="Equation y=F(t)", default="0")
-    zstring: StringProperty(name="Z equation", description="Equation z=F(t)",
-                            default="0.05*sin(2*pi*4*t)")
+    xstring: StringProperty(
+        name="X equation",
+        description="Equation x=F(t)",
+        default="t",
+    )
+    ystring: StringProperty(
+        name="Y equation",
+        description="Equation y=F(t)",
+        default="0",
+    )
+    zstring: StringProperty(
+        name="Z equation",
+        description="Equation z=F(t)",
+        default="0.05*sin(2*pi*4*t)",
+    )
 
-    iteration: bpy.props.IntProperty(name="iteration", default=100, min=50, max=2000)
-    maxt: bpy.props.FloatProperty(name="Wave ends at x", default=0.5,
-                                  min=-3.0, max=10, precision=4, unit="LENGTH")
-    mint: bpy.props.FloatProperty(name="Wave starts at x", default=0,
-                                  min=-3.0, max=3, precision=4, unit="LENGTH")
+    iteration: IntProperty(
+        name="iteration",
+        default=100,
+        min=50,
+        max=2000,
+    )
+    maxt: FloatProperty(
+        name="Wave ends at x",
+        default=0.5,
+        min=-3.0,
+        max=10,
+        precision=4,
+        unit="LENGTH",
+    )
+    mint: FloatProperty(
+        name="Wave starts at x",
+        default=0,
+        min=-3.0,
+        max=3,
+        precision=4,
+        unit="LENGTH",
+    )
 
     def execute(self, context):
         print("x= " + self.xstring)

--- a/scripts/addons/cam/curvecamtools.py
+++ b/scripts/addons/cam/curvecamtools.py
@@ -43,11 +43,16 @@ class CamCurveBoolean(bpy.types.Operator):
     bl_label = "Curve Boolean"
     bl_options = {'REGISTER', 'UNDO'}
 
-    boolean_type: bpy.props.EnumProperty(name='type',
-                                         items=(('UNION', 'Union', ''), ('DIFFERENCE', 'Difference', ''),
-                                                ('INTERSECT', 'Intersect', '')),
-                                         description='boolean type',
-                                         default='UNION')
+    boolean_type: EnumProperty(
+        name='type',
+        items=(
+            ('UNION', 'Union', ''),
+            ('DIFFERENCE', 'Difference', ''),
+            ('INTERSECT', 'Intersect', '')
+        ),
+        description='boolean type',
+        default='UNION'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -84,20 +89,62 @@ class CamCurveIntarsion(bpy.types.Operator):
     bl_label = "Intarsion"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    diameter: bpy.props.FloatProperty(name="cutter diameter", default=.001, min=0, max=0.025, precision=4,
-                                      unit="LENGTH")
-    tolerance: bpy.props.FloatProperty(name="cutout Tolerance", default=.0001, min=0, max=0.005, precision=4,
-                                       unit="LENGTH")
-    backlight: bpy.props.FloatProperty(name="Backlight seat", default=0.000, min=0, max=0.010, precision=4,
-                                       unit="LENGTH")
-    perimeter_cut: bpy.props.FloatProperty(name="Perimeter cut offset", default=0.000, min=0, max=0.100, precision=4,
-                                           unit="LENGTH")
-    base_thickness: bpy.props.FloatProperty(name="Base material thickness", default=0.000, min=0, max=0.100,
-                                            precision=4, unit="LENGTH")
-    intarsion_thickness: bpy.props.FloatProperty(name="Intarsion material thickness", default=0.000, min=0, max=0.100,
-                                                 precision=4, unit="LENGTH")
-    backlight_depth_from_top: bpy.props.FloatProperty(name="Backlight well depth", default=0.000, min=0, max=0.100,
-                                                      precision=4, unit="LENGTH")
+    diameter: FloatProperty(
+        name="cutter diameter",
+        default=.001,
+        min=0,
+        max=0.025,
+        precision=4,
+        unit="LENGTH",
+    )
+    tolerance: FloatProperty(
+        name="cutout Tolerance",
+        default=.0001,
+        min=0,
+        max=0.005,
+        precision=4,
+        unit="LENGTH",
+    )
+    backlight: FloatProperty(
+        name="Backlight seat",
+        default=0.000,
+        min=0,
+        max=0.010,
+        precision=4,
+        unit="LENGTH",
+    )
+    perimeter_cut: FloatProperty(
+        name="Perimeter cut offset",
+        default=0.000,
+        min=0,
+        max=0.100,
+        precision=4,
+        unit="LENGTH",
+    )
+    base_thickness: FloatProperty(
+        name="Base material thickness",
+        default=0.000,
+        min=0,
+        max=0.100,
+        precision=4,
+        unit="LENGTH",
+    )
+    intarsion_thickness: FloatProperty(
+        name="Intarsion material thickness",
+        default=0.000,
+        min=0,
+        max=0.100,
+        precision=4,
+        unit="LENGTH",
+    )
+    backlight_depth_from_top: FloatProperty(
+        name="Backlight well depth",
+        default=0.000,
+        min=0,
+        max=0.100,
+        precision=4,
+        unit="LENGTH",
+    )
 
     @classmethod
     def poll(cls, context):
@@ -125,7 +172,8 @@ class CamCurveIntarsion(bpy.types.Operator):
         o1.select_set(True)
         o2.select_set(True)
         o3.select_set(False)
-        bpy.ops.object.delete(use_global=False)  # delete o1 and o2 temporary working curves
+        # delete o1 and o2 temporary working curves
+        bpy.ops.object.delete(use_global=False)
         o3.name = "intarsion_pocket"  # this is the pocket for intarsion
         bpy.context.object.location[2] = -self.intarsion_thickness
 
@@ -146,7 +194,8 @@ class CamCurveIntarsion(bpy.types.Operator):
         o4.select_set(False)
 
         if self.backlight > 0.0:  # Make a smaller curve for backlighting purposes
-            utils.silhoueteOffset(context, (-self.tolerance / 2) - self.backlight)
+            utils.silhoueteOffset(
+                context, (-self.tolerance / 2) - self.backlight)
             bpy.context.active_object.name = "intarsion_backlight"
             bpy.context.object.location[2] = - \
                 self.backlight_depth_from_top - self.intarsion_thickness
@@ -162,12 +211,31 @@ class CamCurveOvercuts(bpy.types.Operator):
     bl_label = "Add Overcuts"
     bl_options = {'REGISTER', 'UNDO'}
 
-    diameter: bpy.props.FloatProperty(
-        name="diameter", default=.003175, min=0, max=100, precision=4, unit="LENGTH")
-    threshold: bpy.props.FloatProperty(name="threshold", default=math.pi / 2 * .99, min=-3.14, max=3.14, precision=4,
-                                       subtype="ANGLE", unit="ROTATION")
-    do_outer: bpy.props.BoolProperty(name="Outer polygons", default=True)
-    invert: bpy.props.BoolProperty(name="Invert", default=False)
+    diameter: FloatProperty(
+        name="diameter",
+        default=.003175,
+        min=0,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    threshold: FloatProperty(
+        name="threshold",
+        default=math.pi / 2 * .99,
+        min=-3.14,
+        max=3.14,
+        precision=4,
+        subtype="ANGLE",
+        unit="ROTATION",
+    )
+    do_outer: BoolProperty(
+        name="Outer polygons",
+        default=True,
+    )
+    invert: BoolProperty(
+        name="Invert",
+        default=False,
+    )
 
     @classmethod
     def poll(cls, context):
@@ -198,9 +266,11 @@ class CamCurveOvercuts(bpy.types.Operator):
                         if i2 == len(c.coords):
                             i2 = 0
 
-                        v1 = mathutils.Vector(co) - mathutils.Vector(c.coords[i1])
+                        v1 = mathutils.Vector(
+                            co) - mathutils.Vector(c.coords[i1])
                         v1 = v1.xy  # Vector((v1.x,v1.y,0))
-                        v2 = mathutils.Vector(c.coords[i2]) - mathutils.Vector(co)
+                        v2 = mathutils.Vector(
+                            c.coords[i2]) - mathutils.Vector(co)
                         v2 = v2.xy  # v2 = Vector((v2.x,v2.y,0))
                         if not v1.length == 0 and not v2.length == 0:
                             a = v1.angle_signed(v2)
@@ -217,12 +287,14 @@ class CamCurveOvercuts(bpy.types.Operator):
                                 p = p - v * diameter / 2
                                 if abs(a) < math.pi / 2:
                                     shape = utils.Circle(diameter / 2, 64)
-                                    shape = shapely.affinity.translate(shape, p.x, p.y)
+                                    shape = shapely.affinity.translate(
+                                        shape, p.x, p.y)
                                 else:
                                     l = math.tan(a / 2) * diameter / 2
                                     p1 = p - sign * v * l
                                     l = shapely.geometry.LineString((p, p1))
-                                    shape = l.buffer(diameter / 2, resolution=64)
+                                    shape = l.buffer(
+                                        diameter / 2, resolution=64)
 
                                 if sign > 0:
                                     negative_overcuts.append(shape)
@@ -247,25 +319,52 @@ class CamCurveOvercutsB(bpy.types.Operator):
     bl_label = "Add Overcuts-B"
     bl_options = {'REGISTER', 'UNDO'}
 
-    diameter: bpy.props.FloatProperty(name="Tool diameter", default=.003175,
-                                      description='Tool bit diameter used in cut operation', min=0, max=100,
-                                      precision=4, unit="LENGTH")
-    style: bpy.props.EnumProperty(
+    diameter: FloatProperty(
+        name="Tool diameter",
+        default=.003175,
+        description='Tool bit diameter used in cut operation',
+        min=0,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    style: EnumProperty(
         name="style",
-        items=(('OPEDGE', 'opposite edge', 'place corner overcuts on opposite edges'),
-               ('DOGBONE', 'Dog-bone / Corner Point', 'place overcuts at center of corners'),
-               ('TBONE', 'T-bone', 'place corner overcuts on the same edge')),
+        items=(
+            ('OPEDGE', 'opposite edge',
+             'place corner overcuts on opposite edges'),
+            ('DOGBONE', 'Dog-bone / Corner Point',
+                'place overcuts at center of corners'),
+            ('TBONE', 'T-bone', 'place corner overcuts on the same edge')
+        ),
         default='DOGBONE',
-        description='style of overcut to use')
-    threshold: bpy.props.FloatProperty(name="Max Inside Angle", default=math.pi / 2, min=-3.14, max=3.14,
-                                       description='The maximum angle to be considered as an inside corner',
-                                       precision=4, subtype="ANGLE", unit="ROTATION")
-    do_outer: bpy.props.BoolProperty(name="Include outer curve",
-                                     description='Include the outer curve if there are curves inside', default=True)
-    do_invert: bpy.props.BoolProperty(name="Invert", description='invert overcut operation on all curves',
-                                      default=True)
-    otherEdge: bpy.props.BoolProperty(name="other edge",
-                                      description='change to the other edge for the overcut to be on', default=False)
+        description='style of overcut to use',
+    )
+    threshold: FloatProperty(
+        name="Max Inside Angle",
+        default=math.pi / 2,
+        min=-3.14,
+        max=3.14,
+        description='The maximum angle to be considered as an inside corner',
+        precision=4,
+        subtype="ANGLE",
+        unit="ROTATION",
+    )
+    do_outer: BoolProperty(
+        name="Include outer curve",
+        description='Include the outer curve if there are curves inside',
+        default=True,
+    )
+    do_invert: BoolProperty(
+        name="Invert",
+        description='invert overcut operation on all curves',
+        default=True,
+    )
+    otherEdge: BoolProperty(
+        name="other edge",
+        description='change to the other edge for the overcut to be on',
+        default=False,
+    )
 
     @classmethod
     def poll(cls, context):
@@ -345,7 +444,8 @@ class CamCurveOvercutsB(bpy.types.Operator):
             return delta
 
         for s in shapes.geoms:
-            s = shapely.geometry.polygon.orient(s, 1)  # ensure the shape is counterclockwise
+            # ensure the shape is counterclockwise
+            s = shapely.geometry.polygon.orient(s, 1)
 
             if s.boundary.geom_type == 'LineString':
                 from shapely import MultiLineString
@@ -368,8 +468,10 @@ class CamCurveOvercutsB(bpy.types.Operator):
                         if i2 == len(c.coords):
                             i2 = 0
 
-                        v1 = mathutils.Vector(co).xy - mathutils.Vector(c.coords[i1]).xy
-                        v2 = mathutils.Vector(c.coords[i2]).xy - mathutils.Vector(co).xy
+                        v1 = mathutils.Vector(
+                            co).xy - mathutils.Vector(c.coords[i1]).xy
+                        v2 = mathutils.Vector(
+                            c.coords[i2]).xy - mathutils.Vector(co).xy
 
                         if not v1.length == 0 and not v2.length == 0:
                             a = v1.angle_signed(v2)
@@ -400,7 +502,8 @@ class CamCurveOvercutsB(bpy.types.Operator):
                                     if isTBone:
                                         cornerCnt += 1
                                         # insideCorner tuplet: (pos, v1, v2, angle, corner index)
-                                        insideCorners.append((pos, v1, v2, a, cornerCnt - 1))
+                                        insideCorners.append(
+                                            (pos, v1, v2, a, cornerCnt - 1))
                                         # processing of corners for T-Bone are done after all points are processed
                                         continue
 
@@ -416,7 +519,8 @@ class CamCurveOvercutsB(bpy.types.Operator):
                     # check if t-bone processing required
                     # if no inside corners then nothing to do
                     if isTBone and len(insideCorners) > 0:
-                        print("corner count", cornerCnt, "inside corner count", len(insideCorners))
+                        print("corner count", cornerCnt,
+                              "inside corner count", len(insideCorners))
                         # process all of the inside corners
                         for i, corner in enumerate(insideCorners):
                             pos, v1, v2, a, idx = corner
@@ -427,7 +531,8 @@ class CamCurveOvercutsB(bpy.types.Operator):
                             print('first:', i, idx, prevCorner[IDX])
                             if getCornerDelta(prevCorner[IDX], idx) == 1:
                                 # make sure there is an outside corner
-                                print(getCornerDelta(getCorner(i, -2)[IDX], idx))
+                                print(getCornerDelta(
+                                    getCorner(i, -2)[IDX], idx))
                                 if getCornerDelta(getCorner(i, -2)[IDX], idx) > 2:
                                     setOtherEdge(v1, v2, a)
                                     print('first won')
@@ -437,7 +542,8 @@ class CamCurveOvercutsB(bpy.types.Operator):
                             print('second:', i, idx, nextCorner[IDX])
                             if getCornerDelta(idx, nextCorner[IDX]) == 1:
                                 # make sure there is an outside corner
-                                print(getCornerDelta(idx, getCorner(i, 2)[IDX]))
+                                print(getCornerDelta(
+                                    idx, getCorner(i, 2)[IDX]))
                                 if getCornerDelta(idx, getCorner(i, 2)[IDX]) > 2:
                                     print('second won')
                                     setOtherEdge(-v2, -v1, a)
@@ -446,7 +552,8 @@ class CamCurveOvercutsB(bpy.types.Operator):
                             print('third')
                             if getCornerDelta(prevCorner[IDX], idx) == 3:
                                 # check if they share the same edge
-                                a1 = v1.angle_signed(prevCorner[V2]) * 180.0 / math.pi
+                                a1 = v1.angle_signed(
+                                    prevCorner[V2]) * 180.0 / math.pi
                                 print('third won', a1)
                                 if a1 < -135 or a1 > 135:
                                     setOtherEdge(-v2, -v1, a)
@@ -455,7 +562,8 @@ class CamCurveOvercutsB(bpy.types.Operator):
                             print('fourth')
                             if getCornerDelta(idx, nextCorner[IDX]) == 3:
                                 # check if they share the same edge
-                                a1 = v2.angle_signed(nextCorner[V1]) * 180.0 / math.pi
+                                a1 = v2.angle_signed(
+                                    nextCorner[V1]) * 180.0 / math.pi
                                 print('fourth won', a1)
                                 if a1 < -135 or a1 > 135:
                                     setOtherEdge(v1, v2, a)
@@ -513,13 +621,25 @@ class CamMeshGetPockets(bpy.types.Operator):
     bl_label = "Get pocket surfaces"
     bl_options = {'REGISTER', 'UNDO'}
 
-    threshold: bpy.props.FloatProperty(name="horizontal threshold",
-                                       description="How horizontal the surface must be for a pocket: "
-                                                   "1.0 perfectly flat, 0.0 is any orientation",
-                                       default=.99, min=0, max=1.0, precision=4)
-    zlimit: bpy.props.FloatProperty(name="z limit",
-                                    description="maximum z height considered for pocket operation, default is 0.0",
-                                    default=0.0, min=-1000.0, max=1000.0, precision=4, unit='LENGTH')
+    threshold: FloatProperty(
+        name="horizontal threshold",
+        description="How horizontal the surface must be for a pocket: "
+        "1.0 perfectly flat, 0.0 is any orientation",
+        default=.99,
+        min=0,
+        max=1.0,
+        precision=4,
+    )
+    zlimit: FloatProperty(
+        name="z limit",
+        description="maximum z height considered for pocket operation, "
+        "default is 0.0",
+        default=0.0,
+        min=-1000.0,
+        max=1000.0,
+        precision=4,
+        unit='LENGTH',
+    )
 
     @classmethod
     def poll(cls, context):
@@ -535,7 +655,8 @@ class CamMeshGetPockets(bpy.types.Operator):
                 mw = ob.matrix_world
                 mesh = ob.data
                 bpy.ops.object.editmode_toggle()
-                bpy.ops.mesh.select_mode(use_extend=False, use_expand=False, type='FACE')
+                bpy.ops.mesh.select_mode(
+                    use_extend=False, use_expand=False, type='FACE')
                 bpy.ops.mesh.select_all(action='DESELECT')
                 bpy.ops.object.editmode_toggle()
                 i = 0
@@ -572,11 +693,13 @@ class CamMeshGetPockets(bpy.types.Operator):
 
                     bpy.ops.object.editmode_toggle()
 
-                    bpy.ops.mesh.select_mode(use_extend=False, use_expand=False, type='EDGE')
+                    bpy.ops.mesh.select_mode(
+                        use_extend=False, use_expand=False, type='EDGE')
                     bpy.ops.mesh.region_to_loop()
                     bpy.ops.mesh.separate(type='SELECTED')
 
-                    bpy.ops.mesh.select_mode(use_extend=False, use_expand=False, type='FACE')
+                    bpy.ops.mesh.select_mode(
+                        use_extend=False, use_expand=False, type='FACE')
                     bpy.ops.object.editmode_toggle()
                     ao.select_set(state=False)
                     bpy.context.view_layer.objects.active = bpy.context.selected_objects[0]
@@ -609,13 +732,34 @@ class CamOffsetSilhouete(bpy.types.Operator):
     bl_label = "Silhouete offset"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
-    offset: bpy.props.FloatProperty(name="offset", default=.003,
-                                    min=-100, max=100, precision=4, unit="LENGTH")
-    mitrelimit: bpy.props.FloatProperty(
-        name="Mitre Limit", default=.003, min=0.0, max=20, precision=4, unit="LENGTH")
-    style: bpy.props.EnumProperty(name="type of curve", items=(
-        ('1', 'Round', ''), ('2', 'Mitre', ''), ('3', 'Bevel', '')))
-    opencurve: bpy.props.BoolProperty(name="Dialate open curve", default=False)
+    offset: FloatProperty(
+        name="offset",
+        default=.003,
+        min=-100,
+        max=100,
+        precision=4,
+        unit="LENGTH",
+    )
+    mitrelimit: FloatProperty(
+        name="Mitre Limit",
+        default=.003,
+        min=0.0,
+        max=20,
+        precision=4,
+        unit="LENGTH",
+    )
+    style: EnumProperty(
+        name="type of curve",
+        items=(
+            ('1', 'Round', ''),
+            ('2', 'Mitre', ''),
+            ('3', 'Bevel', '')
+        ),
+    )
+    opencurve: BoolProperty(
+        name="Dialate open curve",
+        default=False,
+    )
 
     @classmethod
     def poll(cls, context):
@@ -623,7 +767,8 @@ class CamOffsetSilhouete(bpy.types.Operator):
             context.active_object.type == 'CURVE' or context.active_object.type == 'FONT' or
             context.active_object.type == 'MESH')
 
-    def execute(self, context):  # this is almost same as getobjectoutline, just without the need of operation data
+    # this is almost same as getobjectoutline, just without the need of operation data
+    def execute(self, context):
         bpy.ops.object.curve_remove_doubles()
         ob = context.active_object
         if self.opencurve and ob.type == 'CURVE':
@@ -642,14 +787,16 @@ class CamOffsetSilhouete(bpy.types.Operator):
             simple.remove_multiple('temp_mesh')  # delete temporary mesh
             simple.remove_multiple('dilation')  # delete old dilation objects
 
-            line = LineString(coords)  # convert coordinates to shapely LineString datastructure
+            # convert coordinates to shapely LineString datastructure
+            line = LineString(coords)
             print("line length=", round(line.length * 1000), 'mm')
 
             dilated = line.buffer(self.offset, cap_style=1, resolution=16,
                                   mitre_limit=self.mitrelimit)  # use shapely to expand
             polygon_utils_cam.shapelyToCurve("dilation", dilated, 0)
         else:
-            utils.silhoueteOffset(context, self.offset, int(self.style), self.mitrelimit)
+            utils.silhoueteOffset(context, self.offset,
+                                  int(self.style), self.mitrelimit)
         return {'FINISHED'}
 
 
@@ -668,13 +815,16 @@ class CamObjectSilhouete(bpy.types.Operator):
             context.active_object.type == 'FONT' or
             context.active_object.type == 'MESH')
 
-    def execute(self, context):  # this is almost same as getobjectoutline, just without the need of operation data
+    # this is almost same as getobjectoutline, just without the need of operation data
+    def execute(self, context):
         ob = bpy.context.active_object
-        self.silh = utils.getObjectSilhouete('OBJECTS', objects=bpy.context.selected_objects)
+        self.silh = utils.getObjectSilhouete(
+            'OBJECTS', objects=bpy.context.selected_objects)
         bpy.context.scene.cursor.location = (0, 0, 0)
         # smp=sgeometry.asMultiPolygon(self.silh)
         for smp in self.silh:
-            polygon_utils_cam.shapelyToCurve(ob.name + '_silhouette', smp, 0)  #
+            polygon_utils_cam.shapelyToCurve(
+                ob.name + '_silhouette', smp, 0)  #
         # bpy.ops.object.convert(target='CURVE')
         bpy.context.scene.cursor.location = ob.location
         bpy.ops.object.origin_set(type='ORIGIN_CURSOR')

--- a/scripts/addons/cam/ops.py
+++ b/scripts/addons/cam/ops.py
@@ -87,7 +87,8 @@ def timer_update(context):
                     update_zbufferimage_tag = False
                     update_offsetimage_tag = False
                 else:
-                    readthread = threading.Thread(target=threadread, args=([tcom]), daemon=True)
+                    readthread = threading.Thread(
+                        target=threadread, args=([tcom]), daemon=True)
                     readthread.start()
                     p[0] = readthread
             o = s.cam_operations[tcom.opname]  # changes
@@ -118,7 +119,8 @@ class PathsBackground(bpy.types.Operator):
                                 bufsize=1, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
 
         tcom = threadCom(o, proc)
-        readthread = threading.Thread(target=threadread, args=([tcom]), daemon=True)
+        readthread = threading.Thread(
+            target=threadread, args=([tcom]), daemon=True)
         readthread.start()
         # self.__class__.cam_processes=[]
         if not hasattr(bpy.ops.object.calculate_cam_paths_background.__class__, 'cam_processes'):
@@ -258,7 +260,8 @@ class PathsAll(bpy.types.Operator):
 
     def draw(self, context):
         layout = self.layout
-        layout.prop_search(self, "operation", bpy.context.scene, "cam_operations")
+        layout.prop_search(self, "operation",
+                           bpy.context.scene, "cam_operations")
 
 
 class CamPackObjects(bpy.types.Operator):
@@ -325,11 +328,13 @@ class PathsChain(bpy.types.Operator, AsyncOperatorMixin):
         meshes = []
         try:
             for i in range(0, len(chainops)):
-                s.cam_active_operation = s.cam_operations.find(chainops[i].name)
+                s.cam_active_operation = s.cam_operations.find(
+                    chainops[i].name)
                 self.report({'INFO'}, f"Calculating path: {chainops[i].name}")
                 result, success = await _calc_path(self, context)
                 if not success and 'FINISHED' in result:
-                    self.report({'ERROR'}, f"Couldn't calculate path: {chainops[i].name}")
+                    self.report(
+                        {'ERROR'}, f"Couldn't calculate path: {chainops[i].name}")
         except Exception as e:
             print("FAIL", e)
             traceback.print_tb(e.__traceback__)
@@ -397,8 +402,11 @@ class CAMSimulate(bpy.types.Operator, AsyncOperatorMixin):
     bl_label = "CAM simulation"
     bl_options = {'REGISTER', 'UNDO', 'BLOCKING'}
 
-    operation: StringProperty(name="Operation",
-                              description="Specify the operation to calculate", default='Operation')
+    operation: StringProperty(
+        name="Operation",
+        description="Specify the operation to calculate",
+        default='Operation',
+    )
 
     async def execute_async(self, context):
         s = bpy.context.scene
@@ -418,7 +426,8 @@ class CAMSimulate(bpy.types.Operator, AsyncOperatorMixin):
 
     def draw(self, context):
         layout = self.layout
-        layout.prop_search(self, "operation", bpy.context.scene, "cam_operations")
+        layout.prop_search(self, "operation",
+                           bpy.context.scene, "cam_operations")
 
 
 class CAMSimulateChain(bpy.types.Operator, AsyncOperatorMixin):
@@ -434,8 +443,11 @@ class CAMSimulateChain(bpy.types.Operator, AsyncOperatorMixin):
         chain = s.cam_chains[s.cam_active_chain]
         return cam.isChainValid(chain, context)[0]
 
-    operation: StringProperty(name="Operation",
-                              description="Specify the operation to calculate", default='Operation')
+    operation: StringProperty(
+        name="Operation",
+        description="Specify the operation to calculate",
+        default='Operation',
+    )
 
     async def execute_async(self, context):
         s = bpy.context.scene
@@ -459,7 +471,8 @@ class CAMSimulateChain(bpy.types.Operator, AsyncOperatorMixin):
 
     def draw(self, context):
         layout = self.layout
-        layout.prop_search(self, "operation", bpy.context.scene, "cam_operations")
+        layout.prop_search(self, "operation",
+                           bpy.context.scene, "cam_operations")
 
 
 class CamChainAdd(bpy.types.Operator):
@@ -643,7 +656,8 @@ class CamOperationAdd(bpy.types.Operator):
 
         ob = bpy.context.active_object
         if ob is None:
-            self.report({'ERROR_INVALID_INPUT'}, "Please add an object to base the operation on.")
+            self.report({'ERROR_INVALID_INPUT'},
+                        "Please add an object to base the operation on.")
             return {'CANCELLED'}
 
         minx, miny, minz, maxx, maxy, maxz = utils.getBoundsWorldspace([ob])
@@ -704,7 +718,8 @@ class CamOperationCopy(bpy.types.Operator):
                 numdigits += 1
                 isdigit = o.name[-numdigits].isdigit()
             numdigits -= 1
-            o.name = o.name[:-numdigits] + str(int(o.name[-numdigits:]) + 1).zfill(numdigits)
+            o.name = o.name[:-numdigits] + \
+                str(int(o.name[-numdigits:]) + 1).zfill(numdigits)
             o.filename = o.name
         else:
             o.name = o.name + '_copy'
@@ -754,9 +769,15 @@ class CamOperationMove(bpy.types.Operator):
     bl_label = "Move CAM operation in list"
     bl_options = {'REGISTER', 'UNDO'}
 
-    direction: EnumProperty(name='direction',
-                            items=(('UP', 'Up', ''), ('DOWN', 'Down', '')),
-                            description='direction', default='DOWN')
+    direction: EnumProperty(
+        name='direction',
+        items=(
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        description='direction',
+        default='DOWN',
+    )
 
     @classmethod
     def poll(cls, context):
@@ -800,7 +821,8 @@ class CamOrientationAdd(bpy.types.Operator):
         oriob.empty_draw_size = 0.02  # 2 cm
 
         simple.addToGroup(oriob, gname)
-        oriob.name = 'ori_' + o.name + '.' + str(len(bpy.data.collections[gname].objects)).zfill(3)
+        oriob.name = 'ori_' + o.name + '.' + \
+            str(len(bpy.data.collections[gname].objects)).zfill(3)
 
         return {'FINISHED'}
 

--- a/scripts/addons/cam/ui_panels/info.py
+++ b/scripts/addons/cam/ui_panels/info.py
@@ -1,4 +1,6 @@
 import bpy
+from bpy.props import StringProperty
+from bpy.props import FloatProperty
 
 from cam.simple import strInUnits
 from cam.ui_panels.buttons_panel import CAMButtonsPanel
@@ -12,21 +14,25 @@ from cam.version import __version__ as cam_version
 
 class CAM_INFO_Properties(bpy.types.PropertyGroup):
 
-    warnings: bpy.props.StringProperty(
+    warnings: StringProperty(
         name='warnings',
         description='warnings',
         default='',
-        update=cam.utils.update_operation)
+        update=cam.utils.update_operation,
+    )
 
-    chipload: bpy.props.FloatProperty(
+    chipload: FloatProperty(
         name="chipload", description="Calculated chipload",
         default=0.0, unit='LENGTH',
-        precision=cam.constants.CHIPLOAD_PRECISION)
+        precision=cam.constants.CHIPLOAD_PRECISION,
+    )
 
-    duration: bpy.props.FloatProperty(
+    duration: FloatProperty(
         name="Estimated time", default=0.01, min=0.0000,
         max=cam.constants.MAX_OPERATION_TIME,
-        precision=cam.constants.PRECISION, unit="TIME")
+        precision=cam.constants.PRECISION,
+        unit="TIME",
+    )
 
 
 class CAM_INFO_Panel(CAMButtonsPanel, bpy.types.Panel):
@@ -48,7 +54,8 @@ class CAM_INFO_Panel(CAMButtonsPanel, bpy.types.Panel):
     def draw_blendercam_version(self):
         if not self.has_correct_level():
             return
-        self.layout.label(text=f'Blendercam version: {".".join([str(x) for x in cam_version])}')
+        self.layout.label(
+            text=f'Blendercam version: {".".join([str(x) for x in cam_version])}')
         if len(bpy.context.preferences.addons['cam'].preferences.new_version_available) > 0:
             self.layout.label(text=f"New version available:")
             self.layout.label(

--- a/scripts/addons/cam/ui_panels/interface.py
+++ b/scripts/addons/cam/ui_panels/interface.py
@@ -1,5 +1,6 @@
-
 import bpy
+from bpy.props import EnumProperty
+
 import math
 from cam.ui_panels.buttons_panel import CAMButtonsPanel
 import cam.utils
@@ -13,7 +14,7 @@ def update_interface(self, context):
 
 
 class CAM_INTERFACE_Properties(bpy.types.PropertyGroup):
-    level: bpy.props.EnumProperty(
+    level: EnumProperty(
         name="Interface",
         description="Choose visible options",
         items=[('0', "Basic", "Only show essential options"),
@@ -21,7 +22,7 @@ class CAM_INTERFACE_Properties(bpy.types.PropertyGroup):
                ('2', "Complete", "Show all options"),
                ('3', "Experimental", "Show experimental options")],
         default='0',
-        update=update_interface
+        update=update_interface,
     )
 
 

--- a/scripts/addons/cam/ui_panels/material.py
+++ b/scripts/addons/cam/ui_panels/material.py
@@ -1,5 +1,9 @@
-
 import bpy
+from bpy.props import BoolProperty
+from bpy.props import EnumProperty
+from bpy.props import FloatProperty
+from bpy.props import FloatVectorProperty
+
 from cam.ui_panels.buttons_panel import CAMButtonsPanel
 import cam.utils
 import cam.constants
@@ -7,53 +11,61 @@ import cam.constants
 
 class CAM_MATERIAL_Properties(bpy.types.PropertyGroup):
 
-    estimate_from_model: bpy.props.BoolProperty(
+    estimate_from_model: BoolProperty(
         name="Estimate cut area from model",
         description="Estimate cut area based on model geometry",
         default=True,
-        update=cam.utils.update_material
+        update=cam.utils.update_material,
     )
 
-    radius_around_model: bpy.props.FloatProperty(
+    radius_around_model: FloatProperty(
         name='Radius around model',
-        description="Increase cut area around the model on X and Y by this amount",
+        description="Increase cut area around the model on X and "
+        "Y by this amount",
         default=0.0, unit='LENGTH', precision=cam.constants.PRECISION,
-        update=cam.utils.update_material
+        update=cam.utils.update_material,
     )
 
-    center_x: bpy.props.BoolProperty(
+    center_x: BoolProperty(
         name="Center on X axis",
         description="Position model centered on X",
-        default=False, update=cam.utils.update_material
+        default=False, update=cam.utils.update_material,
     )
 
-    center_y: bpy.props.BoolProperty(
+    center_y: BoolProperty(
         name="Center on Y axis",
         description="Position model centered on Y",
-        default=False, update=cam.utils.update_material
+        default=False, update=cam.utils.update_material,
     )
 
-    z_position: bpy.props.EnumProperty(
+    z_position: EnumProperty(
         name="Z placement", items=(
             ('ABOVE', 'Above', 'Place object vertically above the XY plane'),
             ('BELOW', 'Below', 'Place object vertically below the XY plane'),
-            ('CENTERED', 'Centered', 'Place object vertically centered on the XY plane')),
-        description="Position below Zero", default='BELOW',
-        update=cam.utils.update_material
+            ('CENTERED', 'Centered',
+             'Place object vertically centered on the XY plane')
+        ),
+        description="Position below Zero",
+        default='BELOW',
+        update=cam.utils.update_material,
     )
 
     # material_origin
-    origin: bpy.props.FloatVectorProperty(
+    origin: FloatVectorProperty(
         name='Material origin', default=(0, 0, 0), unit='LENGTH',
         precision=cam.constants.PRECISION, subtype="XYZ",
-        update=cam.utils.update_material
+        update=cam.utils.update_material,
     )
 
     # material_size
-    size: bpy.props.FloatVectorProperty(
-        name='Material size', default=(0.200, 0.200, 0.100), min=0, unit='LENGTH',
-        precision=cam.constants.PRECISION, subtype="XYZ",
-        update=cam.utils.update_material
+    size: FloatVectorProperty(
+        name='Material size',
+        default=(0.200, 0.200, 0.100),
+        min=0,
+        unit='LENGTH',
+        precision=cam.constants.PRECISION,
+        subtype="XYZ",
+        update=cam.utils.update_material,
     )
 
 
@@ -78,7 +90,8 @@ class CAM_MATERIAL_PositionObject(bpy.types.Operator):
     def draw(self, context):
         if not self.interface_level <= int(self.context.scene.interface.level):
             return
-        self.layout.prop_search(self, "operation", bpy.context.scene, "cam_operations")
+        self.layout.prop_search(
+            self, "operation", bpy.context.scene, "cam_operations")
 
 
 class CAM_MATERIAL_Panel(CAMButtonsPanel, bpy.types.Panel):
@@ -106,7 +119,8 @@ class CAM_MATERIAL_Panel(CAMButtonsPanel, bpy.types.Panel):
             if self.op.material.estimate_from_model:
                 row_radius = self.layout.row()
                 row_radius.label(text="Additional radius")
-                row_radius.prop(self.op.material, 'radius_around_model', text='')
+                row_radius.prop(self.op.material,
+                                'radius_around_model', text='')
             else:
                 self.layout.prop(self.op.material, 'origin')
                 self.layout.prop(self.op.material, 'size')
@@ -120,7 +134,8 @@ class CAM_MATERIAL_Panel(CAMButtonsPanel, bpy.types.Panel):
             row_axis.prop(self.op.material, 'center_x')
             row_axis.prop(self.op.material, 'center_y')
             self.layout.prop(self.op.material, 'z_position')
-            self.layout.operator("object.material_cam_position", text="Position object")
+            self.layout.operator(
+                "object.material_cam_position", text="Position object")
 
     def draw(self, context):
         self.context = context

--- a/scripts/addons/cam/ui_panels/movement.py
+++ b/scripts/addons/cam/ui_panels/movement.py
@@ -1,5 +1,8 @@
-
 import bpy
+from bpy.props import BoolProperty
+from bpy.props import EnumProperty
+from bpy.props import FloatProperty
+
 import math
 from cam.ui_panels.buttons_panel import CAMButtonsPanel
 import cam.utils
@@ -8,99 +11,196 @@ import cam.constants
 
 class CAM_MOVEMENT_Properties(bpy.types.PropertyGroup):
     # movement parallel_step_back
-    type: bpy.props.EnumProperty(name='Movement type', items=(
-        ('CONVENTIONAL', 'Conventional / Up milling',
-         'cutter rotates against the direction of the feed'),
-        ('CLIMB', 'Climb / Down milling',
-            'cutter rotates with the direction of the feed'),
-        ('MEANDER', 'Meander / Zig Zag',
-            'cutting is done both with and against the rotation of the spindle')),
-        description='movement type', default='CLIMB', update=cam.utils.update_operation)
+    type: EnumProperty(
+        name='Movement type',
+        items=(
+            ('CONVENTIONAL', 'Conventional / Up milling',
+             'cutter rotates against the direction of the feed'),
+            ('CLIMB', 'Climb / Down milling',
+             'cutter rotates with the direction of the feed'),
+            ('MEANDER', 'Meander / Zig Zag',
+             'cutting is done both with and against the '
+             'rotation of the spindle')
+        ),
+        description='movement type',
+        default='CLIMB',
+        update=cam.utils.update_operation,
+    )
 
-    insideout: bpy.props.EnumProperty(name='Direction',
-                                      items=(('INSIDEOUT', 'Inside out', 'a'),
-                                             ('OUTSIDEIN', 'Outside in', 'a')),
-                                      description='approach to the piece', default='INSIDEOUT',
-                                      update=cam.utils.update_operation)
+    insideout: EnumProperty(
+        name='Direction',
+        items=(
+            ('INSIDEOUT', 'Inside out', 'a'),
+            ('OUTSIDEIN', 'Outside in', 'a')
+        ),
+        description='approach to the piece',
+        default='INSIDEOUT',
+        update=cam.utils.update_operation,
+    )
 
-    spindle_rotation: bpy.props.EnumProperty(name='Spindle rotation',
-                                             items=(('CW', 'Clock wise', 'a'),
-                                                    ('CCW', 'Counter clock wise', 'a')),
-                                             description='Spindle rotation direction', default='CW',
-                                             update=cam.utils.update_operation)
+    spindle_rotation: EnumProperty(
+        name='Spindle rotation',
+        items=(
+            ('CW', 'Clock wise', 'a'),
+            ('CCW', 'Counter clock wise', 'a')
+        ),
+        description='Spindle rotation direction',
+        default='CW',
+        update=cam.utils.update_operation,
+    )
 
-    free_height: bpy.props.FloatProperty(name="Free movement height",
-                                         default=0.01, min=0.0000, max=32,
-                                         precision=cam.constants.PRECISION, unit="LENGTH",
-                                         update=cam.utils.update_operation)
+    free_height: FloatProperty(
+        name="Free movement height",
+        default=0.01,
+        min=0.0000,
+        max=32,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=cam.utils.update_operation,
+    )
 
-    useG64: bpy.props.BoolProperty(name="G64 trajectory",
-                                   description='Use only if your machine supports G64 code. LinuxCNC and Mach3 do',
-                                   default=False, update=cam.utils.update_operation)
+    useG64: BoolProperty(
+        name="G64 trajectory",
+        description='Use only if your machine supports '
+        'G64 code. LinuxCNC and Mach3 do',
+        default=False,
+        update=cam.utils.update_operation,
+    )
 
-    G64: bpy.props.FloatProperty(name="Path Control Mode with Optional Tolerance",
-                                 default=0.0001, min=0.0000, max=0.005,
-                                 precision=cam.constants.PRECISION, unit="LENGTH", update=cam.utils.update_operation)
+    G64: FloatProperty(
+        name="Path Control Mode with Optional Tolerance",
+        default=0.0001,
+        min=0.0000,
+        max=0.005,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=cam.utils.update_operation,
+    )
 
-    parallel_step_back: bpy.props.BoolProperty(name="Parallel step back",
-                                               description='For roughing and finishing in one pass: mills material in climb mode, then steps back and goes between 2 last chunks back',
-                                               default=False, update=cam.utils.update_operation)
+    parallel_step_back: BoolProperty(
+        name="Parallel step back",
+        description='For roughing and finishing in one pass: mills '
+        'material in climb mode, then steps back and goes '
+        'between 2 last chunks back',
+        default=False,
+        update=cam.utils.update_operation,
+    )
 
-    helix_enter: bpy.props.BoolProperty(name="Helix enter - EXPERIMENTAL",
-                                        description="Enter material in helix",
-                                        default=False, update=cam.utils.update_operation)
+    helix_enter: BoolProperty(
+        name="Helix enter - EXPERIMENTAL",
+        description="Enter material in helix",
+        default=False,
+        update=cam.utils.update_operation,
+    )
 
-    ramp_in_angle: bpy.props.FloatProperty(name="Ramp in angle", default=math.pi / 6,
-                                           min=0, max=math.pi * 0.4999,
-                                           precision=1, subtype="ANGLE", unit="ROTATION", update=cam.utils.update_operation)
+    ramp_in_angle: FloatProperty(
+        name="Ramp in angle",
+        default=math.pi / 6,
+        min=0,
+        max=math.pi * 0.4999,
+        precision=1,
+        subtype="ANGLE",
+        unit="ROTATION",
+        update=cam.utils.update_operation,
+    )
 
-    helix_diameter: bpy.props.FloatProperty(name='Helix diameter - % of cutter diameter',
-                                            default=90, min=10, max=100,
-                                            precision=1, subtype='PERCENTAGE', update=cam.utils.update_operation)
+    helix_diameter: FloatProperty(
+        name='Helix diameter - % of cutter diameter',
+        default=90,
+        min=10,
+        max=100,
+        precision=1,
+        subtype='PERCENTAGE',
+        update=cam.utils.update_operation,
+    )
 
-    ramp: bpy.props.BoolProperty(name="Ramp in - EXPERIMENTAL",
-                                 description="Ramps down the whole contour, so the cutline looks like helix",
-                                 default=False, update=cam.utils.update_operation)
+    ramp: BoolProperty(
+        name="Ramp in - EXPERIMENTAL",
+        description="Ramps down the whole contour, so the cutline looks "
+        "like helix",
+        default=False,
+        update=cam.utils.update_operation,
+    )
 
-    ramp_out: bpy.props.BoolProperty(name="Ramp out - EXPERIMENTAL",
-                                     description="Ramp out to not leave mark on surface", default=False,
-                                     update=cam.utils.update_operation)
+    ramp_out: BoolProperty(
+        name="Ramp out - EXPERIMENTAL",
+        description="Ramp out to not leave mark on surface",
+        default=False,
+        update=cam.utils.update_operation,
+    )
 
-    ramp_out_angle: bpy.props.FloatProperty(name="Ramp out angle",
-                                            default=math.pi / 6, min=0, max=math.pi * 0.4999,
-                                            precision=1, subtype="ANGLE", unit="ROTATION", update=cam.utils.update_operation)
+    ramp_out_angle: FloatProperty(
+        name="Ramp out angle",
+        default=math.pi / 6,
+        min=0,
+        max=math.pi * 0.4999,
+        precision=1,
+        subtype="ANGLE",
+        unit="ROTATION",
+        update=cam.utils.update_operation,
+    )
 
-    retract_tangential: bpy.props.BoolProperty(name="Retract tangential - EXPERIMENTAL",
-                                               description="Retract from material in circular motion", default=False,
-                                               update=cam.utils.update_operation)
+    retract_tangential: BoolProperty(
+        name="Retract tangential - EXPERIMENTAL",
+        description="Retract from material in circular motion",
+        default=False,
+        update=cam.utils.update_operation,
+    )
 
-    retract_radius: bpy.props.FloatProperty(name='Retract arc radius',
-                                            default=0.001, min=0.000001, max=100,
-                                            precision=cam.constants.PRECISION, unit="LENGTH",
-                                            update=cam.utils.update_operation)
+    retract_radius: FloatProperty(
+        name='Retract arc radius',
+        default=0.001,
+        min=0.000001,
+        max=100,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=cam.utils.update_operation,
+    )
 
-    retract_height: bpy.props.FloatProperty(name='Retract arc height',
-                                            default=0.001, min=0.00000, max=100,
-                                            precision=cam.constants.PRECISION, unit="LENGTH",
-                                            update=cam.utils.update_operation)
+    retract_height: FloatProperty(
+        name='Retract arc height',
+        default=0.001,
+        min=0.00000,
+        max=100,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=cam.utils.update_operation,
+    )
 
-    stay_low: bpy.props.BoolProperty(name="Stay low if possible",
-                                     default=True, update=cam.utils.update_operation)
+    stay_low: BoolProperty(
+        name="Stay low if possible",
+        default=True,
+        update=cam.utils.update_operation,
+    )
 
-    merge_dist: bpy.props.FloatProperty(name="Merge distance - EXPERIMENTAL",
-                                        default=0.0, min=0.0000, max=0.1,
-                                        precision=cam.constants.PRECISION, unit="LENGTH",
-                                        update=cam.utils.update_operation)
+    merge_dist: FloatProperty(
+        name="Merge distance - EXPERIMENTAL",
+        default=0.0,
+        min=0.0000,
+        max=0.1,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=cam.utils.update_operation,
+    )
 
-    protect_vertical: bpy.props.BoolProperty(name="Protect vertical",
-                                             description="The path goes only vertically next to steep areas",
-                                             default=True,
-                                             update=cam.utils.update_operation)
+    protect_vertical: BoolProperty(
+        name="Protect vertical",
+        description="The path goes only vertically next to steep areas",
+        default=True,
+        update=cam.utils.update_operation,
+    )
 
-    protect_vertical_limit: bpy.props.FloatProperty(name="Verticality limit",
-                                                    description="What angle is allready considered vertical",
-                                                    default=math.pi / 45, min=0, max=math.pi * 0.5, precision=0,
-                                                    subtype="ANGLE", unit="ROTATION", update=cam.utils.update_operation)
+    protect_vertical_limit: FloatProperty(
+        name="Verticality limit",
+        description="What angle is allready considered vertical",
+        default=math.pi / 45,
+        min=0,
+        max=math.pi * 0.5,
+        precision=0,
+        subtype="ANGLE",
+        unit="ROTATION",
+        update=cam.utils.update_operation,
+    )
 
 
 class CAM_MOVEMENT_Panel(CAMButtonsPanel, bpy.types.Panel):

--- a/scripts/addons/cam/ui_panels/optimisation.py
+++ b/scripts/addons/cam/ui_panels/optimisation.py
@@ -1,4 +1,8 @@
 import bpy
+from bpy.props import BoolProperty
+from bpy.props import FloatProperty
+from bpy.props import IntProperty
+
 from cam.ui_panels.buttons_panel import CAMButtonsPanel
 import cam.utils
 import cam.constants
@@ -6,45 +10,82 @@ import cam.constants
 
 class CAM_OPTIMISATION_Properties(bpy.types.PropertyGroup):
 
-    optimize: bpy.props.BoolProperty(
-        name="Reduce path points", description="Reduce path points", default=True,
-        update=cam.utils.update_operation)
+    optimize: BoolProperty(
+        name="Reduce path points",
+        description="Reduce path points",
+        default=True,
+        update=cam.utils.update_operation,
+    )
 
-    optimize_threshold: bpy.props.FloatProperty(
-        name="Reduction threshold in μm", default=.2, min=0.000000001,
-        max=1000, precision=20, update=cam.utils.update_operation)
+    optimize_threshold: FloatProperty(
+        name="Reduction threshold in μm",
+        default=.2,
+        min=0.000000001,
+        max=1000,
+        precision=20,
+        update=cam.utils.update_operation,
+    )
 
-    use_exact: bpy.props.BoolProperty(
+    use_exact: BoolProperty(
         name="Use exact mode",
-        description="Exact mode allows greater precision, but is slower with complex meshes",
-        default=True, update=cam.utils.update_exact_mode)
+        description="Exact mode allows greater precision, but is slower "
+        "with complex meshes",
+        default=True,
+        update=cam.utils.update_exact_mode,
+    )
 
-    imgres_limit: bpy.props.IntProperty(
-        name="Maximum resolution in megapixels", default=16, min=1, max=512,
-        description="Limits total memory usage and prevents crashes. Increase it if you know what are doing",
-        update=cam.utils.update_zbuffer_image)
+    imgres_limit: IntProperty(
+        name="Maximum resolution in megapixels",
+        default=16,
+        min=1,
+        max=512,
+        description="Limits total memory usage and prevents crashes. "
+        "Increase it if you know what are doing",
+        update=cam.utils.update_zbuffer_image,
+    )
 
-    pixsize: bpy.props.FloatProperty(
-        name="sampling raster detail", default=0.0001, min=0.00001, max=0.1,
-        precision=cam.constants.PRECISION, unit="LENGTH", update=cam.utils.update_zbuffer_image)
+    pixsize: FloatProperty(
+        name="sampling raster detail",
+        default=0.0001,
+        min=0.00001,
+        max=0.1,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=cam.utils.update_zbuffer_image,
+    )
 
-    use_opencamlib: bpy.props.BoolProperty(
+    use_opencamlib: BoolProperty(
         name="Use OpenCAMLib",
         description="Use OpenCAMLib to sample paths or get waterline shape",
-        default=False, update=cam.utils.update_opencamlib)
+        default=False,
+        update=cam.utils.update_opencamlib,
+    )
 
-    exact_subdivide_edges: bpy.props.BoolProperty(
+    exact_subdivide_edges: BoolProperty(
         name="Auto subdivide long edges",
-        description="This can avoid some collision issues when importing CAD models",
-        default=False, update=cam.utils.update_exact_mode)
+        description="This can avoid some collision issues when "
+        "importing CAD models",
+        default=False,
+        update=cam.utils.update_exact_mode,
+    )
 
-    circle_detail: bpy.props.IntProperty(
-        name="Detail of circles used for curve offsets", default=64, min=12, max=512,
-        update=cam.utils.update_operation)
+    circle_detail: IntProperty(
+        name="Detail of circles used for curve offsets",
+        default=64,
+        min=12,
+        max=512,
+        update=cam.utils.update_operation,
+    )
 
-    simulation_detail: bpy.props.FloatProperty(
-        name="Simulation sampling raster detail", default=0.0002, min=0.00001,
-        max=0.01, precision=cam.constants.PRECISION, unit="LENGTH", update=cam.utils.update_operation)
+    simulation_detail: FloatProperty(
+        name="Simulation sampling raster detail",
+        default=0.0002,
+        min=0.00001,
+        max=0.01,
+        precision=cam.constants.PRECISION,
+        unit="LENGTH",
+        update=cam.utils.update_operation,
+    )
 
 
 class CAM_OPTIMISATION_Panel(CAMButtonsPanel, bpy.types.Panel):


### PR DESCRIPTION
Changed the formatting of Properties (e.g. bpy.props.StringProperty) throughout:

Before:
```python
use_position_definitions: bpy.props.BoolProperty(name="Use position definitions",
                                                     description="Define own positions for op start, "
                                                                 "toolchange, ending position",
                                                     default=False)
```

After:
```python
use_position_definitions: BoolProperty(
        name="Use position definitions",
        description="Define own positions for op start, "
        "toolchange, ending position",
        default=False,
)
```

Added trailing commas to retain formatting if another autoformatter (e.g.: black) is implemented.
Removed bpy.props. prefix from Properties that still had it, and added explicit imports when required in ui_panels module.