### PR TITLE
Numba machine fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 </div>
 
 ## 👁️ About
-BlenderCAM is an add-on for the free open-source [Blender 3D package](https://www.blender.org/).
+BlenderCAM is an add-on for the free open-source [Blender 3D package](https://www.blender.org/) .
 
 It offers an open source solution for [CAM _(Computer Aided Machining)_](https://en.wikipedia.org/wiki/Computer-aided_manufacturing) toolpath generation, simulation and [G-code](https://en.wikipedia.org/wiki/G-code) export.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 </div>
 
 ## 👁️ About
-BlenderCAM is an add-on for the free open-source [Blender 3D package](https://www.blender.org/) .
+BlenderCAM is an add-on for the free open-source [Blender 3D package](https://www.blender.org/).
 
 It offers an open source solution for [CAM _(Computer Aided Machining)_](https://en.wikipedia.org/wiki/Computer-aided_manufacturing) toolpath generation, simulation and [G-code](https://en.wikipedia.org/wiki/G-code) export.
 

--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -28,8 +28,9 @@ except ModuleNotFoundError:
     subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", " pip"])
     subprocess.check_call([sys.executable, "-m", "pip", "install",
                            "shapely", "Equation", "opencamlib"])
+    # Numba Install temporarily disabled after crash report
     # install numba if available for this platform, ignore failure
-    subprocess.run([sys.executable, "-m", "pip", "install", "numba"])
+    # subprocess.run([sys.executable, "-m", "pip", "install", "numba"])
 
 from shapely import geometry as sgeometry  # noqa
 
@@ -100,7 +101,7 @@ from pathlib import Path
 bl_info = {
     "name": "CAM - gcode generation tools",
     "author": "Vilem Novak & Contributors",
-    "version":(1,0,12),
+    "version": (1, 0, 12),
     "blender": (3, 6, 0),
     "location": "Properties > render",
     "description": "Generate machining paths for CNC",

--- a/scripts/addons/cam/ops.py
+++ b/scripts/addons/cam/ops.py
@@ -44,7 +44,7 @@ from . import (
 )
 from .utils import (
     was_hidden_dict,
-    reload_pathss,
+    reload_paths,
     isValid,
     isChainValid,
     silhoueteOffset,
@@ -193,13 +193,9 @@ async def _calc_path(operator, context):
         ob = bpy.data.objects[o.object_name]
         ob.select_set(True)
         bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)'''
-    if bpy.context.mode != 'OBJECT':
-        bpy.ops.object.mode_set(mode='OBJECT')	    # force object mode
-    bpy.ops.object.select_all(action='DESELECT')
-    path = bpy.data.objects.get('cam_path_{}'.format(o.name))
-    if path:
-        path.select_set(state=True)
-        bpy.ops.object.delete()
+    mesh = bpy.data.meshes.get(f'cam_path_{o.name}')
+    if mesh:
+        bpy.data.meshes.remove(mesh)
 
     if not o.valid:
         operator.report({'ERROR_INVALID_INPUT'},

--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -1710,7 +1710,7 @@ def rotTo2axes(e, axescombination):
     return (angle1, angle2)
 
 
-def reload_pathss(o):
+def reload_paths(o):
     oname = "cam_path_" + o.name
     s = bpy.context.scene
     # for o in s.objects:
@@ -1769,11 +1769,12 @@ USE_PROFILER = False
 
 was_hidden_dict = {}
 
+_IS_LOADING_DEFAULTS = False
+
 
 def updateMachine(self, context):
-    global _IS_LOADING_DEFAULTS
     print('update machine ')
-    if not _IS_LOADING_DEFAULTS:
+    if not utils._IS_LOADING_DEFAULTS:
         addMachineAreaObject()
 
 


### PR DESCRIPTION
Commented out `numba` import from the `__init__` for now, until the issues with crashing can be resolved.

Moved `_IS_LOADING_DEFAULTS` out of the `updateMachine` function, declared the default `= False`, and grabbed it via `utils.IS_LOADING_DEFAULTS`.

_Note: It was already declared a `global` variable within the function, and I thought that would have been enough to avoid this error, but it works now_

Lastly, altered the cleanup in the `_calc_path` function in `ops.py` - previously it was checking for and deleting objects without issues. 

In Blender 4.0 and previous, deleting an object would also delete its associated mesh data.

In Blender 4.1 deleting an object would still leave behind mesh data that retained the object name, causing the cleanup function to not recognize and update old operations.

Simply deleting the mesh data solves the issue, as it will also delete the object with it, even though the reverse is no longer true.

_Note: This may be a bug in 4.1, but the new method also works in 4.0, so I don't think it will need to change, even if Blender restores the previous behavior_