### PR TITLE
Title Case for Labels, Bridges Fix, README Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ BlenderCAM works on Windows or Linux.
 ```graphql
 .
 ├── config - # 'startup' and 'userpref' blend files
-├── documentation - # Markdown guides and images
+├── documentation - # How to Use (Wiki) - files
 ├── Examples - # Bas Relief & Intarsion operation demo files and images
 ├── scripts
 │   └── addons
@@ -108,12 +108,12 @@ BlenderCAM works on Windows or Linux.
 │           ├── nc - # Post-Processors
 │           ├── opencamlib - # OpenCAMLib functions
 │           ├── presets - # Quick access to pre-defined cutting tools, machines and operations
-│           |   ├── cam_cutters
-│           |   ├── cam_machines
-│           |   └── cam_operations
-|           ├── tests - # Developer Tests
-|           |   └── test_data - # Test output
-|           └── ui_panels - # User Interface
+│           │   ├── cam_cutters
+│           │   ├── cam_machines
+│           │   └── cam_operations
+│           ├── tests - # Developer Tests
+│           │   └── test_data - # Test output
+│           └── ui_panels - # User Interface
 └── static - # Logo
 
 ```

--- a/scripts/addons/cam/async_op.py
+++ b/scripts/addons/cam/async_op.py
@@ -6,7 +6,7 @@ import bpy
 
 @types.coroutine
 def progress_async(text, n=None, value_type='%'):
-    """function for reporting during the script, works for background operations in the header."""
+    """Function for Reporting During the Script, Works for Background Operations in the Header."""
     throw_exception = yield ('progress', {'text': text, 'n': n, "value_type": value_type})
     if throw_exception is not None:
         raise throw_exception
@@ -65,7 +65,7 @@ class AsyncOperatorMixin:
             self.coroutine = self.execute_async(context)
         try:
             if self._is_cancelled:
-                (msg, args) = self.coroutine.send(AsyncCancelledException("Cancelled with ESC key"))
+                (msg, args) = self.coroutine.send(AsyncCancelledException("Cancelled with ESC Key"))
                 raise StopIteration
             else:
                 (msg, args) = self.coroutine.send(None)
@@ -77,7 +77,7 @@ class AsyncOperatorMixin:
         except StopIteration:
             return False
         except Exception as e:
-            print("Exception thrown in tick:", e)
+            print("Exception Thrown in Tick:", e)
 
     def execute(self, context):
         if bpy.app.background:
@@ -93,9 +93,9 @@ class AsyncOperatorMixin:
 
 
 class AsyncTestOperator(bpy.types.Operator, AsyncOperatorMixin):
-    """test async operator"""
+    """Test Async Operator"""
     bl_idname = "object.cam_async_test_operator"
-    bl_label = "Test operator for async stuff"
+    bl_label = "Test Operator for Async Stuff"
     bl_options = {'REGISTER', 'UNDO', 'BLOCKING'}
 
     async def execute_async(self, context):

--- a/scripts/addons/cam/autoupdate.py
+++ b/scripts/addons/cam/autoupdate.py
@@ -16,9 +16,9 @@ from .version import __version__ as current_version
 
 
 class UpdateChecker(bpy.types.Operator):
-    """check for updates"""
+    """Check for Updates"""
     bl_idname = "render.cam_check_updates"
-    bl_label = "Check for updates in blendercam plugin"
+    bl_label = "Check for Updates in BlenderCAM Plugin"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
@@ -31,7 +31,7 @@ class UpdateChecker(bpy.types.Operator):
         if match:
             update_source = f"https://api.github.com/repos/{match.group(1)}/releases"
 
-        print(f"update check: {update_source}")
+        print(f"Update Check: {update_source}")
         if update_source == "None" or len(update_source) == 0:
             return {'FINISHED'}
 
@@ -46,7 +46,7 @@ class UpdateChecker(bpy.types.Operator):
                 if len(release_list) > 0:
                     release = release_list[0]
                     tag = release["tag_name"]
-                    print(f"Found release: {tag}")
+                    print(f"Found Release: {tag}")
                     match = re.match(r".*(\d+)\.(\s*\d+)\.(\s*\d+)", tag)
                     if match:
                         version_num = tuple(map(int, match.groups()))
@@ -71,13 +71,13 @@ class UpdateChecker(bpy.types.Operator):
 
 
 class Updater(bpy.types.Operator):
-    """update to newer version if possible """
+    """Update to Newer Version if Possible"""
     bl_idname = "render.cam_update_now"
     bl_label = "Update"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
-        print("update check")
+        print("Update Check")
         last_update_check = bpy.context.preferences.addons['cam'].preferences.last_update_check
         today = date.today().toordinal()
         update_source = bpy.context.preferences.addons['cam'].preferences.update_source
@@ -96,7 +96,7 @@ class Updater(bpy.types.Operator):
                 if len(release_list) > 0:
                     release = release_list[0]
                     tag = release["tag_name"]
-                    print(f"Found release: {tag}")
+                    print(f"Found Release: {tag}")
                     match = re.match(r".*(\d+)\.(\s*\d+)\.(\s*\d+)", tag)
                     if match:
                         version_num = tuple(map(int, match.groups()))
@@ -105,7 +105,7 @@ class Updater(bpy.types.Operator):
                         bpy.ops.wm.save_userpref()
 
                         if version_num > current_version:
-                            print("Version is newer, downloading source")
+                            print("Version Is Newer, Downloading Source")
                             zip_url = release["zipball_url"]
                             self.install_zip_from_url(zip_url)
                             return {'FINISHED'}
@@ -166,7 +166,7 @@ class Updater(bpy.types.Operator):
 
 class UpdateSourceOperator(bpy.types.Operator):
     bl_idname = "render.cam_set_update_source"
-    bl_label = "Set blendercam update source"
+    bl_label = "Set BlenderCAM Update Source"
 
     new_source: StringProperty(
         default='',

--- a/scripts/addons/cam/basrelief.py
+++ b/scripts/addons/cam/basrelief.py
@@ -557,7 +557,7 @@ def numpysave(a, iname):
 
 def numpytoimage(a, iname):
     t = time.time()
-    print('numpy to image - here')
+    print('Numpy to Image - Here')
     t = time.time()
     print(a.shape[0], a.shape[1])
     foundimage = False
@@ -625,7 +625,7 @@ def tonemap(i, exponent):
 
 
 def vert(column, row, z, XYscaling, Zscaling):
-    """ Create a single vert """
+    """ Create a Single Vert """
     return column * XYscaling, row * XYscaling, z * Zscaling
 
 
@@ -641,7 +641,7 @@ def buildMesh(mesh_z, br):
             bpy.data.objects.remove(object)
             print("old basrelief removed")
 
-    print("Building mesh")
+    print("Building Mesh")
     numY = mesh_z.shape[1]
     numX = mesh_z.shape[0]
     print(numX, numY)
@@ -687,24 +687,24 @@ def buildMesh(mesh_z, br):
     bpy.context.active_object.location = (float(
         br.justifyx)*br.widthmm/1000, float(br.justifyy)*br.heightmm/1000, float(br.justifyz)*br.thicknessmm/1000)
 
-    print("faces:" + str(len(ob.data.polygons)))
-    print("vertices:" + str(len(ob.data.vertices)))
+    print("Faces:" + str(len(ob.data.polygons)))
+    print("Vertices:" + str(len(ob.data.vertices)))
     if decimateRatio > 0.95:
-        print("skipping decimate ratio > 0.95")
+        print("Skipping Decimate Ratio > 0.95")
     else:
         m = ob.modifiers.new(name="Foo", type='DECIMATE')
         m.ratio = decimateRatio
-        print("decimating with ratio:"+str(decimateRatio))
+        print("Decimating with Ratio:"+str(decimateRatio))
         bpy.ops.object.modifier_apply(modifier=m.name)
-        print("decimated")
-        print("faces:" + str(len(ob.data.polygons)))
-        print("vertices:" + str(len(ob.data.vertices)))
+        print("Decimated")
+        print("Faces:" + str(len(ob.data.polygons)))
+        print("Vertices:" + str(len(ob.data.vertices)))
 
 # Switches to cycles render to CYCLES to render the sceen then switches it back to BLENDERCAM_RENDER for basRelief
 
 
 def renderScene(width, height, bit_diameter, passes_per_radius, make_nodes, view_layer):
-    print("rendering scene")
+    print("Rendering Scene")
     scene = bpy.context.scene
     # make sure we're in object mode or else bad things happen
     if bpy.context.active_object:
@@ -745,7 +745,7 @@ def renderScene(width, height, bit_diameter, passes_per_radius, make_nodes, view
     if our_viewer is not None:
         nodes.remove(our_viewer)
     bpy.context.scene.render.engine = 'BLENDERCAM_RENDER'
-    print("done rendering")
+    print("Done Rendering")
 
 
 def problemAreas(br):
@@ -869,7 +869,7 @@ def relief(br):
     print("Range:", nar.min(), nar.max())
     if nar.min() - nar.max() == 0:
         raise ReliefError(
-            "Input image is blank - check you have the correct view layer or input image set.")
+            "Input Image Is Blank - Check You Have the Correct View Layer or Input Image Set.")
 
     gx = nar.copy()
     gx.fill(0)
@@ -994,20 +994,20 @@ def relief(br):
 
 class BasReliefsettings(bpy.types.PropertyGroup):
     use_image_source: BoolProperty(
-        name="Use image source",
+        name="Use Image Source",
         description="",
         default=False,
     )
     source_image_name: StringProperty(
-        name='Image source',
+        name='Image Source',
         description='image source',
     )
     view_layer_name: StringProperty(
-        name='View layer source',
+        name='View Layer Source',
         description='Make a bas-relief from whatever is on this view layer',
     )
     bit_diameter: FloatProperty(
-        name="Diameter of ball end in mm",
+        name="Diameter of Ball End in mm",
         description="Diameter of bit which will be used for carving",
         min=0.01,
         max=50.0,
@@ -1015,7 +1015,7 @@ class BasReliefsettings(bpy.types.PropertyGroup):
         precision=PRECISION,
     )
     pass_per_radius: IntProperty(
-        name="Passes per radius",
+        name="Passes per Radius",
         description="Amount of passes per radius\n(more passes, "
         "more mesh precision)",
         default=2,
@@ -1023,13 +1023,13 @@ class BasReliefsettings(bpy.types.PropertyGroup):
         max=10,
     )
     widthmm: IntProperty(
-        name="Desired width in mm",
+        name="Desired Width in mm",
         default=200,
         min=5,
         max=4000,
     )
     heightmm: IntProperty(
-        name="Desired height in mm",
+        name="Desired Height in mm",
         default=150,
         min=5,
         max=4000,
@@ -1070,7 +1070,7 @@ class BasReliefsettings(bpy.types.PropertyGroup):
     )
 
     depth_exponent: FloatProperty(
-        name="Depth exponent",
+        name="Depth Exponent",
         description="Initial depth map is taken to this power. Higher = "
         "sharper relief",
         min=0.5,
@@ -1080,7 +1080,7 @@ class BasReliefsettings(bpy.types.PropertyGroup):
     )
 
     silhouette_threshold: FloatProperty(
-        name="Silhouette threshold",
+        name="Silhouette Threshold",
         description="Silhouette threshold",
         min=0.000001,
         max=1.0,
@@ -1088,12 +1088,12 @@ class BasReliefsettings(bpy.types.PropertyGroup):
         precision=PRECISION,
     )
     recover_silhouettes: BoolProperty(
-        name="Recover silhouettes",
+        name="Recover Silhouettes",
         description="",
         default=True,
     )
     silhouette_scale: FloatProperty(
-        name="Silhouette scale",
+        name="Silhouette Scale",
         description="Silhouette scale",
         min=0.000001,
         max=5.0,
@@ -1101,15 +1101,15 @@ class BasReliefsettings(bpy.types.PropertyGroup):
         precision=PRECISION,
     )
     silhouette_exponent: IntProperty(
-        name="Silhouette square exponent",
-        description="If lower, true depht distances between objects will be "
+        name="Silhouette Square Exponent",
+        description="If lower, true depth distances between objects will be "
         "more visibe in the relief",
         default=3,
         min=0,
         max=5,
     )
     attenuation: FloatProperty(
-        name="Gradient attenuation",
+        name="Gradient Attenuation",
         description="Gradient attenuation",
         min=0.000001,
         max=100.0,
@@ -1117,39 +1117,39 @@ class BasReliefsettings(bpy.types.PropertyGroup):
         precision=PRECISION,
     )
     min_gridsize: IntProperty(
-        name="Minimum grid size",
+        name="Minimum Grid Size",
         default=16,
         min=2,
         max=512,
     )
     smooth_iterations: IntProperty(
-        name="Smooth iterations",
+        name="Smooth Iterations",
         default=1,
         min=1,
         max=64,
     )
     vcycle_iterations: IntProperty(
-        name="V-cycle iterations",
-        description="set up higher for plananr constraint",
+        name="V-Cycle Iterations",
+        description="Set higher for planar constraint",
         default=2,
         min=1,
         max=128,
     )
     linbcg_iterations: IntProperty(
-        name="Linbcg iterations",
-        description="set lower for flatter relief, and when using "
+        name="LINBCG Iterations",
+        description="Set lower for flatter relief, and when using "
         "planar constraint",
         default=5,
         min=1,
         max=64,
     )
     use_planar: BoolProperty(
-        name="Use planar constraint",
+        name="Use Planar Constraint",
         description="",
         default=False,
     )
     gradient_scaling_mask_use: BoolProperty(
-        name="Scale gradients with mask",
+        name="Scale Gradients with Mask",
         description="",
         default=False,
     )
@@ -1164,16 +1164,16 @@ class BasReliefsettings(bpy.types.PropertyGroup):
     )
 
     gradient_scaling_mask_name: StringProperty(
-        name='Scaling mask name',
-        description='mask name',
+        name='Scaling Mask Name',
+        description='Mask name',
     )
     scale_down_before_use: BoolProperty(
-        name="Scale down image before processing",
+        name="Scale Down Image Before Processing",
         description="",
         default=False,
     )
     scale_down_before: FloatProperty(
-        name="Image scale",
+        name="Image Scale",
         description="Image scale",
         min=0.025,
         max=1.0,
@@ -1181,13 +1181,13 @@ class BasReliefsettings(bpy.types.PropertyGroup):
         precision=PRECISION,
     )
     detail_enhancement_use: BoolProperty(
-        name="Enhance details ",
-        description="enhance details by frequency analysis",
+        name="Enhance Details",
+        description="Enhance details by frequency analysis",
         default=False,
     )
     #detail_enhancement_freq=FloatProperty(name="frequency limit", description="Image scale", min=0.025, max=1.0, default=.5, precision=PRECISION)
     detail_enhancement_amount: FloatProperty(
-        name="amount",
+        name="Amount",
         description="Image scale",
         min=0.025,
         max=1.0,
@@ -1196,15 +1196,15 @@ class BasReliefsettings(bpy.types.PropertyGroup):
     )
 
     advanced: BoolProperty(
-        name="Advanced options",
-        description="show advanced options",
+        name="Advanced Options",
+        description="Show advanced options",
         default=True,
     )
 
 
 class BASRELIEF_Panel(bpy.types.Panel):
-    """Bas relief panel"""
-    bl_label = "Bas relief"
+    """Bas Relief Panel"""
+    bl_label = "Bas Relief"
     bl_idname = "WORLD_PT_BASRELIEF"
 
     bl_space_type = "PROPERTIES"
@@ -1229,7 +1229,7 @@ class BASRELIEF_Panel(bpy.types.Panel):
 
         # if br:
         # cutter preset
-        layout.operator("scene.calculate_bas_relief", text="Calculate relief")
+        layout.operator("scene.calculate_bas_relief", text="Calculate Relief")
         layout.prop(br, 'advanced')
         layout.prop(br, 'use_image_source')
         if br.use_image_source:
@@ -1238,7 +1238,7 @@ class BASRELIEF_Panel(bpy.types.Panel):
             layout.prop_search(br, 'view_layer_name',
                                bpy.context.scene, "view_layers")
         layout.prop(br, 'depth_exponent')
-        layout.label(text="Project parameters")
+        layout.label(text="Project Parameters")
         layout.prop(br, 'bit_diameter')
         layout.prop(br, 'pass_per_radius')
         layout.prop(br, 'widthmm')
@@ -1293,9 +1293,9 @@ class ReliefError(Exception):
 
 
 class DoBasRelief(bpy.types.Operator):
-    """calculate Bas relief"""
+    """Calculate Bas Relief"""
     bl_idname = "scene.calculate_bas_relief"
-    bl_label = "calculate Bas relief"
+    bl_label = "Calculate Bas Relief"
     bl_options = {'REGISTER', 'UNDO'}
 
     processes = []
@@ -1322,9 +1322,9 @@ class DoBasRelief(bpy.types.Operator):
 
 
 class ProblemAreas(bpy.types.Operator):
-    """find Bas relief Problem areas"""
+    """Find Bas Relief Problem Areas"""
     bl_idname = "scene.problemareas_bas_relief"
-    bl_label = "problem areas Bas relief"
+    bl_label = "Problem Areas Bas Relief"
     bl_options = {'REGISTER', 'UNDO'}
 
     processes = []

--- a/scripts/addons/cam/bridges.py
+++ b/scripts/addons/cam/bridges.py
@@ -58,7 +58,7 @@ def addBridge(x, y, rot, sizex, sizey):
 
 
 def addAutoBridges(o):
-    """attempt to add auto bridges as set of curves"""
+    """Attempt to Add Auto Bridges as Set of Curves"""
     utils.getOperationSources(o)
     bridgecollectionname = o.bridges_collection_name
     if bridgecollectionname == '' or bpy.data.collections.get(bridgecollectionname) is None:
@@ -124,7 +124,7 @@ def getBridgesPoly(o):
 
 
 def useBridges(ch, o):
-    """this adds bridges to chunks, takes the bridge-objects collection and uses the curves inside it as bridges."""
+    """This Adds Bridges to Chunks, Takes the Bridge-objects Collection and Uses the Curves Inside It as Bridges."""
     bridgecollectionname = o.bridges_collection_name
     bridgecollection = bpy.data.collections[bridgecollectionname]
     if len(bridgecollection.objects) > 0:

--- a/scripts/addons/cam/cam_chunk.py
+++ b/scripts/addons/cam/cam_chunk.py
@@ -318,7 +318,7 @@ class camPathChunk:
         self.rotations.reverse()
 
     def pop(self, index):
-        print("WARNING: Popping from chunk is slow", self, index)
+        print("WARNING: Popping from Chunk Is Slow", self, index)
         self.points = np.concatenate(
             (self.points[0:index], self.points[index + 1:]), axis=0
         )
@@ -391,7 +391,7 @@ class camPathChunk:
                 self.rotations[at_index:at_index] = rotations
 
     def clip_points(self, minx, maxx, miny, maxy):
-        """remove any points outside this range"""
+        """Remove Any Points Outside This Range"""
         included_values = (self.points[:, 0] >= minx) and (
             (self.points[:, 0] <= maxx)
             and (self.points[:, 1] >= maxy)
@@ -700,12 +700,12 @@ class camPathChunk:
 
         if self.parents:  # if it is inside another parent
             perimeterDirection ^= 1  # toggle with a bitwise XOR
-            print("has parent")
+            print("Has Parent")
 
         if perimeterDirection == 1:
-            print("path direction is Clockwise")
+            print("Path Direction Is Clockwise")
         else:
-            print("path direction is counterclockwise")
+            print("Path Direction Is Counter Clockwise")
         iradius = o.lead_in
         oradius = o.lead_out
         start = self.points[0]
@@ -797,7 +797,7 @@ def _optimize_internal(
         return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2]
 
     def _applyVerticalLimit(v1, v2, cos_limit):
-        """test path segment on verticality threshold, for protect_vertical option"""
+        """Test Path Segment on Verticality Threshold, for Protect_vertical Option"""
         z = abs(v1[2] - v2[2])
         if z > 0:
             # don't use this vector because dot product of 0,0,1 is trivially just v2[2]
@@ -1147,7 +1147,7 @@ def meshFromCurveToChunk(object):
     lastvi = 0
     vtotal = len(mesh.vertices)
     perc = 0
-    progress("processing curve - START - Vertices: " + str(vtotal))
+    progress("Processing Curve - START - Vertices: " + str(vtotal))
     for vi in range(0, len(mesh.vertices) - 1):
         co = (mesh.vertices[vi].co + object.location).to_tuple()
         if not dk.isdisjoint([(vi, vi + 1)]) and d[(vi, vi + 1)] == 1:
@@ -1173,7 +1173,7 @@ def meshFromCurveToChunk(object):
                 chunks.append(chunk)
             chunk = camPathChunkBuilder()
 
-    progress("processing curve - FINISHED")
+    progress("Processing Curve - FINISHED")
 
     vi = len(mesh.vertices) - 1
     chunk.points.append(
@@ -1238,7 +1238,7 @@ def meshFromCurve(o, use_modifiers=False):
         bpy.ops.object.convert(target="CURVE", keep_original=False)
     elif co.type != "CURVE":  # curve must be a curve...
         bpy.ops.object.delete()  # delete temporary object
-        raise CamException("Source curve object must be of type CURVE")
+        raise CamException("Source Curve Object Must Be of Type Curve")
     co.data.dimensions = "3D"
     co.data.bevel_depth = 0
     co.data.extrude = 0
@@ -1305,7 +1305,7 @@ def chunkToShapely(chunk):
 
 
 def chunksRefine(chunks, o):
-    """add extra points in between for chunks"""
+    """Add Extra Points in Between for Chunks"""
     for ch in chunks:
         # print('before',len(ch))
         newchunk = []
@@ -1338,7 +1338,7 @@ def chunksRefine(chunks, o):
 
 
 def chunksRefineThreshold(chunks, distance, limitdistance):
-    """add extra points in between for chunks. For medial axis strategy only !"""
+    """Add Extra Points in Between for Chunks. for Medial Axis Strategy only!"""
     for ch in chunks:
         newchunk = []
         v2 = Vector(ch.points[0])

--- a/scripts/addons/cam/cam_operation.py
+++ b/scripts/addons/cam/cam_operation.py
@@ -57,17 +57,17 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     filename: StringProperty(
-        name="File name",
+        name="File Name",
         default="Operation",
         update=updateRest,
     )
     auto_export: BoolProperty(
-        name="Auto export",
-        description="export files immediately after path calculation",
+        name="Auto Export",
+        description="Export files immediately after path calculation",
         default=True,
     )
     remove_redundant_points: BoolProperty(
-        name="Symplify Gcode",
+        name="Simplify G-code",
         description="Remove redundant points sharing the same angle"
                     " as the start vector",
         default=False,
@@ -80,19 +80,19 @@ class camOperation(PropertyGroup):
         max=1000,
     )
     hide_all_others: BoolProperty(
-        name="Hide all others",
-        description="Hide all other tool pathes except toolpath"
-                    " assotiated with selected CAM operation",
+        name="Hide All Others",
+        description="Hide all other tool paths except toolpath"
+                    " associated with selected CAM operation",
         default=False,
     )
     parent_path_to_object: BoolProperty(
-        name="Parent path to object",
+        name="Parent Path to Object",
         description="Parent generated CAM path to source object",
         default=False,
     )
     object_name: StringProperty(
         name='Object',
-        description='object handled by this operation',
+        description='Object handled by this operation',
         update=updateOperationValid,
     )
     collection_name: StringProperty(
@@ -101,26 +101,26 @@ class camOperation(PropertyGroup):
         update=updateOperationValid,
     )
     curve_object: StringProperty(
-        name='Curve source',
-        description='curve which will be sampled along the 3d object',
+        name='Curve Source',
+        description='Curve which will be sampled along the 3D object',
         update=operationValid,
     )
     curve_object1: StringProperty(
-        name='Curve target',
-        description='curve which will serve as attractor for the '
+        name='Curve Target',
+        description='Curve which will serve as attractor for the '
         'cutter when the cutter follows the curve',
         update=operationValid,
     )
     source_image_name: StringProperty(
-        name='image_source',
+        name='Image Source',
         description='image source',
         update=operationValid,
     )
     geometry_source: EnumProperty(
-        name='Source of data',
+        name='Data Source',
         items=(
-            ('OBJECT', 'object', 'a'),
-            ('COLLECTION', 'Collection of objects', 'a'),
+            ('OBJECT', 'Object', 'a'),
+            ('COLLECTION', 'Collection of Objects', 'a'),
             ('IMAGE', 'Image', 'a')
         ),
         description='Geometry source',
@@ -130,30 +130,30 @@ class camOperation(PropertyGroup):
     cutter_type: EnumProperty(
         name='Cutter',
         items=(
-            ('END', 'End', 'end - flat cutter'),
-            ('BALLNOSE', 'Ballnose', 'ballnose cutter'),
-            ('BULLNOSE', 'Bullnose', 'bullnose cutter ***placeholder **'),
-            ('VCARVE', 'V-carve', 'v carve cutter'),
+            ('END', 'End', 'End - Flat cutter'),
+            ('BALLNOSE', 'Ballnose', 'Ballnose cutter'),
+            ('BULLNOSE', 'Bullnose', 'Bullnose cutter ***placeholder **'),
+            ('VCARVE', 'V-carve', 'V-carve cutter'),
             ('BALLCONE', 'Ballcone', 'Ball with a Cone for Parallel - X'),
             ('CYLCONE', 'Cylinder cone',
-             'Cylinder end with a Cone for Parallel - X'),
+             'Cylinder End with a Cone for Parallel - X'),
             ('LASER', 'Laser', 'Laser cutter'),
             ('PLASMA', 'Plasma', 'Plasma cutter'),
             ('CUSTOM', 'Custom-EXPERIMENTAL',
-             'modelled cutter - not well tested yet.')
+             'Modelled cutter - not well tested yet.')
         ),
         description='Type of cutter used',
         default='END',
         update=updateZbufferImage,
     )
     cutter_object_name: StringProperty(
-        name='Cutter object',
-        description='object used as custom cutter for this operation',
+        name='Cutter Object',
+        description='Object used as custom cutter for this operation',
         update=updateZbufferImage,
     )
 
     machine_axes: EnumProperty(
-        name='Number of axes',
+        name='Number of Axes',
         items=(
             ('3', '3 axis', 'a'),
             ('4', '#4 axis - EXPERIMENTAL', 'a'),
@@ -171,7 +171,7 @@ class camOperation(PropertyGroup):
     )
 
     strategy4axis: EnumProperty(
-        name='4 axis Strategy',
+        name='4 Axis Strategy',
         items=(
             ('PARALLELR', 'Parallel around 1st rotary axis',
              'Parallel lines around first rotary axis'),
@@ -191,7 +191,7 @@ class camOperation(PropertyGroup):
         name='Strategy',
         items=(
             ('INDEXED', 'Indexed 3-axis',
-             'all 3 axis strategies, just rotated by 4+5th axes'),
+             'All 3 axis strategies, just rotated by 4+5th axes'),
         ),
         description='5 axis Strategy',
         default='INDEXED',
@@ -199,7 +199,7 @@ class camOperation(PropertyGroup):
     )
 
     rotary_axis_1: EnumProperty(
-        name='Rotary axis',
+        name='Rotary Axis',
         items=(
             ('X', 'X', ''),
             ('Y', 'Y', ''),
@@ -210,7 +210,7 @@ class camOperation(PropertyGroup):
         update=updateStrategy,
     )
     rotary_axis_2: EnumProperty(
-        name='Rotary axis 2',
+        name='Rotary Axis 2',
         items=(
             ('X', 'X', ''),
             ('Y', 'Y', ''),
@@ -232,20 +232,20 @@ class camOperation(PropertyGroup):
         update=updateOffsetImage,
     )
     inverse: BoolProperty(
-        name="Inverse milling",
+        name="Inverse Milling",
         description="Male to female model conversion",
         default=False,
         update=updateOffsetImage,
     )
     array: BoolProperty(
-        name="Use array",
+        name="Use Array",
         description="Create a repetitive array for producing the "
         "same thing many times",
         default=False,
         update=updateRest,
     )
     array_x_count: IntProperty(
-        name="X count",
+        name="X Count",
         description="X count",
         default=1,
         min=1,
@@ -253,7 +253,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     array_y_count: IntProperty(
-        name="Y count",
+        name="Y Count",
         description="Y count",
         default=1,
         min=1,
@@ -261,8 +261,8 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     array_x_distance: FloatProperty(
-        name="X distance",
-        description="distance between operation origins",
+        name="X Distance",
+        description="Distance between operation origins",
         min=0.00001,
         max=1.0,
         default=0.01,
@@ -271,8 +271,8 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     array_y_distance: FloatProperty(
-        name="Y distance",
-        description="distance between operation origins",
+        name="Y Distance",
+        description="Distance between operation origins",
         min=0.00001,
         max=1.0,
         default=0.01,
@@ -293,8 +293,8 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     pocketToCurve: BoolProperty(
-        name="Pocket to curve",
-        description="generates a curve instead of a path",
+        name="Pocket to Curve",
+        description="Generates a curve instead of a path",
         default=False,
         update=updateRest,
     )
@@ -304,14 +304,14 @@ class camOperation(PropertyGroup):
         items=(
             ('OUTSIDE', 'Outside', 'a'),
             ('INSIDE', 'Inside', 'a'),
-            ('ONLINE', 'On line', 'a')
+            ('ONLINE', 'On Line', 'a')
         ),
         description='Type of cutter used',
         default='OUTSIDE',
         update=updateRest,
     )
     outlines_count: IntProperty(
-        name="Outlines count",
+        name="Outlines Count",
         description="Outlines count",
         default=1,
         min=1,
@@ -326,7 +326,7 @@ class camOperation(PropertyGroup):
     )
     # cutter
     cutter_id: IntProperty(
-        name="Tool number",
+        name="Tool Number",
         description="For machines which support tool change based on tool id",
         min=0,
         max=10000,
@@ -334,7 +334,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     cutter_diameter: FloatProperty(
-        name="Cutter diameter",
+        name="Cutter Diameter",
         description="Cutter diameter = 2x cutter radius",
         min=0.000001,
         max=10,
@@ -354,7 +354,7 @@ class camOperation(PropertyGroup):
         update=updateOffsetImage,
     )
     cutter_length: FloatProperty(
-        name="#Cutter length",
+        name="#Cutter Length",
         description="#not supported#Cutter length",
         min=0.0,
         max=100.0,
@@ -364,7 +364,7 @@ class camOperation(PropertyGroup):
         update=updateOffsetImage,
     )
     cutter_flutes: IntProperty(
-        name="Cutter flutes",
+        name="Cutter Flutes",
         description="Cutter flutes",
         min=1,
         max=20,
@@ -372,8 +372,8 @@ class camOperation(PropertyGroup):
         update=updateChipload,
     )
     cutter_tip_angle: FloatProperty(
-        name="Cutter v-carve angle",
-        description="Cutter v-carve angle",
+        name="Cutter V-carve Angle",
+        description="Cutter V-carve angle",
         min=0.0,
         max=180.0,
         default=60.0,
@@ -381,7 +381,7 @@ class camOperation(PropertyGroup):
         update=updateOffsetImage,
     )
     ball_radius: FloatProperty(
-        name="Ball radius",
+        name="Ball Radius",
         description="Radius of",
         min=0.0,
         max=0.035,
@@ -410,46 +410,46 @@ class camOperation(PropertyGroup):
     )
 
     Laser_on: StringProperty(
-        name="Laser ON string",
+        name="Laser ON String",
         default="M68 E0 Q100",
     )
     Laser_off: StringProperty(
-        name="Laser OFF string",
+        name="Laser OFF String",
         default="M68 E0 Q0",
     )
     Laser_cmd: StringProperty(
-        name="Laser command",
+        name="Laser Command",
         default="M68 E0 Q",
     )
     Laser_delay: FloatProperty(
         name="Laser ON Delay",
-        description="time after fast move to turn on laser and "
+        description="Time after fast move to turn on laser and "
         "let machine stabilize",
         default=0.2,
     )
     Plasma_on: StringProperty(
-        name="Plasma ON string",
+        name="Plasma ON String",
         default="M03",
     )
     Plasma_off: StringProperty(
-        name="Plasma OFF string",
+        name="Plasma OFF String",
         default="M05",
     )
     Plasma_delay: FloatProperty(
         name="Plasma ON Delay",
-        description="time after fast move to turn on Plasma and "
+        description="Time after fast move to turn on Plasma and "
         "let machine stabilize",
         default=0.1,
     )
     Plasma_dwell: FloatProperty(
-        name="Plasma dwell time",
+        name="Plasma Dwell Time",
         description="Time to dwell and warm up the torch",
         default=0.0,
     )
 
     # steps
     dist_between_paths: FloatProperty(
-        name="Distance between toolpaths",
+        name="Distance Between Toolpaths",
         default=0.001,
         min=0.00001,
         max=32,
@@ -458,7 +458,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     dist_along_paths: FloatProperty(
-        name="Distance along toolpaths",
+        name="Distance Along Toolpaths",
         default=0.0002,
         min=0.00001,
         max=32,
@@ -467,7 +467,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     parallel_angle: FloatProperty(
-        name="Angle of paths",
+        name="Angle of Paths",
         default=0,
         min=-360,
         max=360,
@@ -478,7 +478,7 @@ class camOperation(PropertyGroup):
     )
 
     old_rotation_A: FloatProperty(
-        name="A axis angle",
+        name="A Axis Angle",
         description="old value of Rotate A axis\nto specified angle",
         default=0,
         min=-360,
@@ -490,7 +490,7 @@ class camOperation(PropertyGroup):
     )
 
     old_rotation_B: FloatProperty(
-        name="A axis angle",
+        name="A Axis Angle",
         description="old value of Rotate A axis\nto specified angle",
         default=0,
         min=-360,
@@ -502,7 +502,7 @@ class camOperation(PropertyGroup):
     )
 
     rotation_A: FloatProperty(
-        name="A axis angle",
+        name="A Axis Angle",
         description="Rotate A axis\nto specified angle",
         default=0,
         min=-360,
@@ -513,7 +513,7 @@ class camOperation(PropertyGroup):
         update=updateRotation,
     )
     enable_A: BoolProperty(
-        name="Enable A axis",
+        name="Enable A Axis",
         description="Rotate A axis",
         default=False,
         update=updateRotation,
@@ -526,7 +526,7 @@ class camOperation(PropertyGroup):
     )
 
     rotation_B: FloatProperty(
-        name="B axis angle",
+        name="B Axis Angle",
         description="Rotate B axis\nto specified angle",
         default=0,
         min=-360,
@@ -537,7 +537,7 @@ class camOperation(PropertyGroup):
         update=updateRotation,
     )
     enable_B: BoolProperty(
-        name="Enable B axis",
+        name="Enable B Axis",
         description="Rotate B axis",
         default=False,
         update=updateRotation,
@@ -545,7 +545,7 @@ class camOperation(PropertyGroup):
 
     # carve only
     carve_depth: FloatProperty(
-        name="Carve depth",
+        name="Carve Depth",
         default=0.001,
         min=-.100,
         max=32,
@@ -556,11 +556,11 @@ class camOperation(PropertyGroup):
 
     # drill only
     drill_type: EnumProperty(
-        name='Holes on',
+        name='Holes On',
         items=(
-            ('MIDDLE_SYMETRIC', 'Middle of symetric curves', 'a'),
-            ('MIDDLE_ALL', 'Middle of all curve parts', 'a'),
-            ('ALL_POINTS', 'All points in curve', 'a')
+            ('MIDDLE_SYMETRIC', 'Middle of Symmetric Curves', 'a'),
+            ('MIDDLE_ALL', 'Middle of All Curve Parts', 'a'),
+            ('ALL_POINTS', 'All Points in Curve', 'a')
         ),
         description='Strategy to detect holes to drill',
         default='MIDDLE_SYMETRIC',
@@ -568,7 +568,7 @@ class camOperation(PropertyGroup):
     )
     # waterline only
     slice_detail: FloatProperty(
-        name="Distance betwen slices",
+        name="Distance Between Slices",
         default=0.001,
         min=0.00001,
         max=32,
@@ -577,13 +577,13 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     waterline_fill: BoolProperty(
-        name="Fill areas between slices",
+        name="Fill Areas Between Slices",
         description="Fill areas between slices in waterline mode",
         default=True,
         update=updateRest,
     )
     waterline_project: BoolProperty(
-        name="Project paths - not recomended",
+        name="Project Paths - Not Recomended",
         description="Project paths in areas between slices",
         default=True,
         update=updateRest,
@@ -607,8 +607,8 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     lead_in: FloatProperty(
-        name="Lead in radius",
-        description="Lead out radius for torch or laser to turn off",
+        name="Lead-in Radius",
+        description="Lead in radius for torch or laser to turn off",
         min=0.00,
         max=1,
         default=0.0,
@@ -616,7 +616,7 @@ class camOperation(PropertyGroup):
         unit="LENGTH",
     )
     lead_out: FloatProperty(
-        name="Lead out radius",
+        name="Lead-out Radius",
         description="Lead out radius for torch or laser to turn off",
         min=0.00,
         max=1,
@@ -625,7 +625,7 @@ class camOperation(PropertyGroup):
         unit="LENGTH",
     )
     profile_start: IntProperty(
-        name="Start point",
+        name="Start Point",
         description="Start point offset",
         min=0,
         default=0,
@@ -635,7 +635,7 @@ class camOperation(PropertyGroup):
     # helix_angle: FloatProperty(name="Helix ramp angle", default=3*pi/180, min=0.00001, max=pi*0.4999,precision=1, subtype="ANGLE" , unit="ROTATION" , update = updateRest)
 
     minz: FloatProperty(
-        name="Operation depth end",
+        name="Operation Depth End",
         default=-0.01,
         min=-3,
         max=3,
@@ -645,7 +645,7 @@ class camOperation(PropertyGroup):
     )
 
     minz_from: EnumProperty(
-        name='Set max depth from',
+        name='Max Depth From',
         description='Set maximum operation depth',
         items=(
             ('OBJECT', 'Object', 'Set max operation depth from Object'),
@@ -657,10 +657,10 @@ class camOperation(PropertyGroup):
     )
 
     start_type: EnumProperty(
-        name='Start type',
+        name='Start Type',
         items=(
             ('ZLEVEL', 'Z level', 'Starts on a given Z level'),
-            ('OPERATIONRESULT', 'Rest milling',
+            ('OPERATIONRESULT', 'Rest Milling',
              'For rest milling, operations have to be '
              'put in chain for this to work well.'),
         ),
@@ -670,7 +670,7 @@ class camOperation(PropertyGroup):
     )
 
     maxz: FloatProperty(
-        name="Operation depth start",
+        name="Operation Depth Start",
         description='operation starting depth',
         default=0,
         min=-3,
@@ -681,7 +681,7 @@ class camOperation(PropertyGroup):
     )  # EXPERIMENTAL
 
     first_down: BoolProperty(
-        name="First down",
+        name="First Down",
         description="First go down on a contour, then go to the next one",
         default=False,
         update=update_operation,
@@ -692,7 +692,7 @@ class camOperation(PropertyGroup):
     ####################################################
 
     source_image_scale_z: FloatProperty(
-        name="Image source depth scale",
+        name="Image Source Depth Scale",
         default=0.01,
         min=-1,
         max=1,
@@ -701,7 +701,7 @@ class camOperation(PropertyGroup):
         update=updateZbufferImage,
     )
     source_image_size_x: FloatProperty(
-        name="Image source x size",
+        name="Image Source X Size",
         default=0.1,
         min=-10,
         max=10,
@@ -710,7 +710,7 @@ class camOperation(PropertyGroup):
         update=updateZbufferImage,
     )
     source_image_offset: FloatVectorProperty(
-        name='Image offset',
+        name='Image Offset',
         default=(0, 0, 0),
         unit='LENGTH',
         precision=constants.PRECISION,
@@ -719,7 +719,7 @@ class camOperation(PropertyGroup):
     )
 
     source_image_crop: BoolProperty(
-        name="Crop source image",
+        name="Crop Source Image",
         description="Crop source image - the position of the sub-rectangle "
         "is relative to the whole image, so it can be used for e.g. "
         "finishing just a part of an image",
@@ -727,7 +727,7 @@ class camOperation(PropertyGroup):
         update=updateZbufferImage,
     )
     source_image_crop_start_x: FloatProperty(
-        name='crop start x',
+        name='Crop Start X',
         default=0,
         min=0,
         max=100,
@@ -736,7 +736,7 @@ class camOperation(PropertyGroup):
         update=updateZbufferImage,
     )
     source_image_crop_start_y: FloatProperty(
-        name='crop start y',
+        name='Crop Start Y',
         default=0,
         min=0,
         max=100,
@@ -745,7 +745,7 @@ class camOperation(PropertyGroup):
         update=updateZbufferImage,
     )
     source_image_crop_end_x: FloatProperty(
-        name='crop end x',
+        name='Crop End X',
         default=100,
         min=0,
         max=100,
@@ -754,7 +754,7 @@ class camOperation(PropertyGroup):
         update=updateZbufferImage,
     )
     source_image_crop_end_y: FloatProperty(
-        name='crop end y',
+        name='Crop End Y',
         default=100,
         min=0,
         max=100,
@@ -770,13 +770,13 @@ class camOperation(PropertyGroup):
     ambient_behaviour: EnumProperty(
         name='Ambient',
         items=(('ALL', 'All', 'a'), ('AROUND', 'Around', 'a')),
-        description='handling ambient surfaces',
+        description='Handling ambient surfaces',
         default='ALL',
         update=updateZbufferImage,
     )
 
     ambient_radius: FloatProperty(
-        name="Ambient radius",
+        name="Ambient Radius",
         description="Radius around the part which will be milled if "
         "ambient is set to Around",
         min=0.0,
@@ -788,21 +788,21 @@ class camOperation(PropertyGroup):
     )
     # ambient_cutter = EnumProperty(name='Borders',items=(('EXTRAFORCUTTER', 'Extra for cutter', "Extra space for cutter is cut around the segment"),('ONBORDER', "Cutter on edge", "Cutter goes exactly on edge of ambient with it's middle") ,('INSIDE', "Inside segment", 'Cutter stays within segment')	 ),description='handling of ambient and cutter size',default='INSIDE')
     use_limit_curve: BoolProperty(
-        name="Use limit curve",
+        name="Use Limit Curve",
         description="A curve limits the operation area",
         default=False,
         update=updateRest,
     )
     ambient_cutter_restrict: BoolProperty(
-        name="Cutter stays in ambient limits",
+        name="Cutter Stays in Ambient Limits",
         description="Cutter doesn't get out from ambient limits otherwise "
         "goes on the border exactly",
         default=True,
         update=updateRest,
     )  # restricts cutter inside ambient only
     limit_curve: StringProperty(
-        name='Limit curve',
-        description='curve used to limit the area of the operation',
+        name='Limit Curve',
+        description='Curve used to limit the area of the operation',
         update=updateRest,
     )
 
@@ -818,7 +818,7 @@ class camOperation(PropertyGroup):
         update=updateChipload,
     )
     plunge_feedrate: FloatProperty(
-        name="Plunge speed ",
+        name="Plunge Speed",
         description="% of feedrate",
         min=0.1,
         max=100.0,
@@ -828,8 +828,8 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     plunge_angle: FloatProperty(
-        name="Plunge angle",
-        description="What angle is allready considered to plunge",
+        name="Plunge Angle",
+        description="What angle is already considered to plunge",
         default=pi / 6,
         min=0,
         max=pi * 0.5,
@@ -839,7 +839,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     spindle_rpm: FloatProperty(
-        name="Spindle rpm",
+        name="Spindle RPM",
         description="Spindle speed ",
         min=0,
         max=60000,
@@ -850,21 +850,21 @@ class camOperation(PropertyGroup):
     # optimization and performance
 
     do_simulation_feedrate: BoolProperty(
-        name="Adjust feedrates with simulation EXPERIMENTAL",
+        name="Adjust Feedrates with Simulation EXPERIMENTAL",
         description="Adjust feedrates with simulation",
         default=False,
         update=updateRest,
     )
 
     dont_merge: BoolProperty(
-        name="Dont merge outlines when cutting",
+        name="Don't Merge Outlines when Cutting",
         description="this is usefull when you want to cut around everything",
         default=False,
         update=updateRest,
     )
 
     pencil_threshold: FloatProperty(
-        name="Pencil threshold",
+        name="Pencil Threshold",
         default=0.00002,
         min=0.00000001,
         max=1,
@@ -874,7 +874,7 @@ class camOperation(PropertyGroup):
     )
 
     crazy_threshold1: FloatProperty(
-        name="min engagement",
+        name="Min Engagement",
         default=0.02,
         min=0.00000001,
         max=100,
@@ -882,7 +882,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     crazy_threshold5: FloatProperty(
-        name="optimal engagement",
+        name="Optimal Engagement",
         default=0.3,
         min=0.00000001,
         max=100,
@@ -890,7 +890,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     crazy_threshold2: FloatProperty(
-        name="max engagement",
+        name="Max Engagement",
         default=0.5,
         min=0.00000001,
         max=100,
@@ -898,7 +898,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     crazy_threshold3: FloatProperty(
-        name="max angle",
+        name="Max Angle",
         default=2,
         min=0.00000001,
         max=100,
@@ -906,7 +906,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     crazy_threshold4: FloatProperty(
-        name="test angle step",
+        name="Test Angle Step",
         default=0.05,
         min=0.00000001,
         max=100,
@@ -915,8 +915,8 @@ class camOperation(PropertyGroup):
     )
     # Add pocket operation to medial axis
     add_pocket_for_medial: BoolProperty(
-        name="Add pocket operation",
-        description="clean unremoved material after medial axis",
+        name="Add Pocket Operation",
+        description="Clean unremoved material after medial axis",
         default=True,
         update=updateRest,
     )
@@ -930,7 +930,7 @@ class camOperation(PropertyGroup):
     )
     ####
     medial_axis_threshold: FloatProperty(
-        name="Long vector threshold",
+        name="Long Vector Threshold",
         default=0.001,
         min=0.00000001,
         max=100,
@@ -939,7 +939,7 @@ class camOperation(PropertyGroup):
         update=updateRest,
     )
     medial_axis_subdivision: FloatProperty(
-        name="Fine subdivision",
+        name="Fine Subdivision",
         default=0.0002,
         min=0.00000001,
         max=100,
@@ -951,20 +951,20 @@ class camOperation(PropertyGroup):
 
     # bridges
     use_bridges: BoolProperty(
-        name="Use bridges",
-        description="use bridges in cutout",
+        name="Use Bridges / Tabs",
+        description="Use bridges in cutout",
         default=False,
         update=updateBridges,
     )
     bridges_width: FloatProperty(
-        name='width of bridges',
+        name='Bridge / Tab Width',
         default=0.002,
         unit='LENGTH',
         precision=constants.PRECISION,
         update=updateBridges,
     )
     bridges_height: FloatProperty(
-        name='height of bridges',
+        name='Bridge / Tab Height',
         description="Height from the bottom of the cutting operation",
         default=0.0005,
         unit='LENGTH',
@@ -972,13 +972,13 @@ class camOperation(PropertyGroup):
         update=updateBridges,
     )
     bridges_collection_name: StringProperty(
-        name='Bridges Collection',
+        name='Bridges / Tabs Collection',
         description='Collection of curves used as bridges',
         update=operationValid,
     )
     use_bridge_modifiers: BoolProperty(
-        name="use bridge modifiers",
-        description="include bridge curve modifiers using render level when "
+        name="Use Bridge / Tab Modifiers",
+        description="Include bridge curve modifiers using render level when "
         "calculating operation, does not effect original bridge data",
         default=True,
         update=updateBridges,
@@ -998,8 +998,8 @@ class camOperation(PropertyGroup):
     # bridges_max_distance = FloatProperty(name = 'Maximum distance between bridges', default=0.08, unit='LENGTH', precision=constants.PRECISION, update = updateBridges)
 
     use_modifiers: BoolProperty(
-        name="use mesh modifiers",
-        description="include mesh modifiers using render level when "
+        name="Use Mesh Modifiers",
+        description="Include mesh modifiers using render level when "
         "calculating operation, does not effect original mesh",
         default=True,
         update=operationValid,
@@ -1013,14 +1013,14 @@ class camOperation(PropertyGroup):
     # MATERIAL SETTINGS
 
     min: FloatVectorProperty(
-        name='Operation minimum',
+        name='Operation Minimum',
         default=(0, 0, 0),
         unit='LENGTH',
         precision=constants.PRECISION,
         subtype="XYZ",
     )
     max: FloatVectorProperty(
-        name='Operation maximum',
+        name='Operation Maximum',
         default=(0, 0, 0),
         unit='LENGTH',
         precision=constants.PRECISION,
@@ -1029,54 +1029,54 @@ class camOperation(PropertyGroup):
 
     # g-code options for operation
     output_header: BoolProperty(
-        name="output g-code header",
-        description="output user defined g-code command header"
+        name="Output G-code Header",
+        description="Output user defined G-code command header"
         " at start of operation",
         default=False,
     )
 
     gcode_header: StringProperty(
-        name="g-code header",
-        description="g-code commands at start of operation."
+        name="G-code Header",
+        description="G-code commands at start of operation."
         " Use ; for line breaks",
         default="G53 G0",
     )
 
     enable_dust: BoolProperty(
-        name="Dust collector",
-        description="output user defined g-code command header"
+        name="Dust Collector",
+        description="Output user defined g-code command header"
         " at start of operation",
         default=False,
     )
 
     gcode_start_dust_cmd: StringProperty(
-        name="Start dust collector",
-        description="commands to start dust collection. Use ; for line breaks",
+        name="Start Dust Collector",
+        description="Commands to start dust collection. Use ; for line breaks",
         default="M100",
     )
 
     gcode_stop_dust_cmd: StringProperty(
-        name="Stop dust collector",
-        description="command to stop dust collection. Use ; for line breaks",
+        name="Stop Dust Collector",
+        description="Command to stop dust collection. Use ; for line breaks",
         default="M101",
     )
 
     enable_hold: BoolProperty(
-        name="Hold down",
-        description="output hold down command at start of operation",
+        name="Hold Down",
+        description="Output hold down command at start of operation",
         default=False,
     )
 
     gcode_start_hold_cmd: StringProperty(
-        name="g-code header",
-        description="g-code commands at start of operation."
+        name="G-code Header",
+        description="G-code commands at start of operation."
         " Use ; for line breaks",
         default="M102",
     )
 
     gcode_stop_hold_cmd: StringProperty(
-        name="g-code header",
-        description="g-code commands at end operation. Use ; for line breaks",
+        name="G-code Header",
+        description="G-code commands at end operation. Use ; for line breaks",
         default="M103",
     )
 
@@ -1087,28 +1087,27 @@ class camOperation(PropertyGroup):
     )
 
     gcode_start_mist_cmd: StringProperty(
-        name="g-code header",
-        description="g-code commands at start of operation."
-        " Use ; for line breaks",
+        name="Start Mist",
+        description="Command to start mist. Use ; for line breaks",
         default="M104",
     )
 
     gcode_stop_mist_cmd: StringProperty(
-        name="g-code header",
-        description="g-code commands at end operation. Use ; for line breaks",
+        name="Stop Mist",
+        description="Command to stop mist. Use ; for line breaks",
         default="M105",
     )
 
     output_trailer: BoolProperty(
-        name="output g-code trailer",
-        description="output user defined g-code command trailer"
+        name="Output G-code Trailer",
+        description="Output user defined g-code command trailer"
         " at end of operation",
         default=False,
     )
 
     gcode_trailer: StringProperty(
-        name="g-code trailer",
-        description="g-code commands at end of operation."
+        name="G-code Trailer",
+        description="G-code commands at end of operation."
         " Use ; for line breaks",
         default="M02",
     )
@@ -1126,40 +1125,40 @@ class camOperation(PropertyGroup):
     borderwidth = 50
     object = None
     path_object_name: StringProperty(
-        name='Path object',
-        description='actual cnc path'
+        name='Path Object',
+        description='Actual CNC path'
     )
 
     # update and tags and related
 
     changed: BoolProperty(
-        name="True if any of the operation settings has changed",
-        description="mark for update",
+        name="True if any of the Operation Settings has Changed",
+        description="Mark for update",
         default=False,
     )
     update_zbufferimage_tag: BoolProperty(
-        name="mark zbuffer image for update",
-        description="mark for update",
+        name="Mark Z-Buffer Image for Update",
+        description="Mark for update",
         default=True,
     )
     update_offsetimage_tag: BoolProperty(
-        name="mark offset image for update",
-        description="mark for update",
+        name="Mark Offset Image for Update",
+        description="Mark for update",
         default=True,
     )
     update_silhouete_tag: BoolProperty(
-        name="mark silhouete image for update",
-        description="mark for update",
+        name="Mark Silhouette Image for Update",
+        description="Mark for update",
         default=True,
     )
     update_ambient_tag: BoolProperty(
-        name="mark ambient polygon for update",
-        description="mark for update",
+        name="Mark Ambient Polygon for Update",
+        description="Mark for update",
         default=True,
     )
     update_bullet_collision_tag: BoolProperty(
-        name="mark bullet collisionworld for update",
-        description="mark for update",
+        name="Mark Bullet Collision World for Update",
+        description="Mark for update",
         default=True,
     )
 
@@ -1169,24 +1168,24 @@ class camOperation(PropertyGroup):
         default=True,
     )
     changedata: StringProperty(
-        name='changedata',
+        name='Changedata',
         description='change data for checking if stuff changed.',
     )
 
     # process related data
 
     computing: BoolProperty(
-        name="Computing right now",
+        name="Computing Right Now",
         description="",
         default=False,
     )
     pid: IntProperty(
-        name="process id",
+        name="Process Id",
         description="Background process id",
         default=-1,
     )
     outtext: StringProperty(
-        name='outtext',
+        name='Outtext',
         description='outtext',
         default='',
     )

--- a/scripts/addons/cam/chain.py
+++ b/scripts/addons/cam/chain.py
@@ -10,7 +10,7 @@ from bpy.types import PropertyGroup
 # this type is defined just to hold reference to operations for chains
 class opReference(PropertyGroup):
     name: StringProperty(
-        name="Operation name",
+        name="Operation Name",
         default="Operation",
     )
     computing = False  # for UiList display
@@ -19,13 +19,13 @@ class opReference(PropertyGroup):
 # chain is just a set of operations which get connected on export into 1 file.
 class camChain(PropertyGroup):
     index: IntProperty(
-        name="index",
-        description="index in the hard-defined camChains",
+        name="Index",
+        description="Index in the hard-defined camChains",
         default=-1,
     )
     active_operation: IntProperty(
-        name="active operation",
-        description="active operation in chain",
+        name="Active Operation",
+        description="Active operation in chain",
         default=-1,
     )
     name: StringProperty(
@@ -33,7 +33,7 @@ class camChain(PropertyGroup):
         default="Chain",
     )
     filename: StringProperty(
-        name="File name",
+        name="File Name",
         default="Chain",
     )  # filename of
     valid: BoolProperty(
@@ -42,7 +42,7 @@ class camChain(PropertyGroup):
         default=True,
     )
     computing: BoolProperty(
-        name="Computing right now",
+        name="Computing Right Now",
         description="",
         default=False,
     )

--- a/scripts/addons/cam/collision.py
+++ b/scripts/addons/cam/collision.py
@@ -45,8 +45,8 @@ from .simple import (
 
 
 def getCutterBullet(o):
-    """cutter for rigidbody simulation collisions
-        note that everything is 100x bigger for simulation precision."""
+    """Cutter for Rigidbody Simulation Collisions
+        Note that Everything Is 100x Bigger for Simulation Precision."""
 
     s = bpy.context.scene
     if s.objects.get('cutter') is not None:
@@ -176,7 +176,7 @@ def getCutterBullet(o):
 
 
 def subdivideLongEdges(ob, threshold):
-    print('subdividing long edges')
+    print('Subdividing Long Edges')
     m = ob.data
     scale = (ob.scale.x + ob.scale.y + ob.scale.z) / 3
     subdivides = []
@@ -220,8 +220,8 @@ def subdivideLongEdges(ob, threshold):
 #
 
 def prepareBulletCollision(o):
-    """prepares all objects needed for sampling with bullet collision"""
-    progress('preparing collisions')
+    """Prepares All Objects Needed for Sampling with Bullet Collision"""
+    progress('Preparing Collisions')
 
     print(o.name)
     active_collection = bpy.context.view_layer.active_layer_collection.collection
@@ -332,7 +332,7 @@ def getSampleBullet(cutter, x, y, radius, startz, endz):
 
 
 def getSampleBulletNAxis(cutter, startpoint, endpoint, rotation, cutter_compensation):
-    """fully 3d collision test for NAxis milling"""
+    """Fully 3D Collision Test for N-Axis Milling"""
     cutterVec = Vector((0, 0, 1)) * cutter_compensation
     # cutter compensation vector - cutter physics object has center in the middle, while cam needs the tip position.
     cutterVec.rotate(Euler(rotation))

--- a/scripts/addons/cam/curvecamcreate.py
+++ b/scripts/addons/cam/curvecamcreate.py
@@ -49,13 +49,13 @@ from . import (
 
 
 class CamCurveHatch(Operator):
-    """perform hatch operation on single or multiple curves"""  # by Alain Pelletier September 2021
+    """Perform Hatch Operation on Single or Multiple Curves"""  # by Alain Pelletier September 2021
     bl_idname = "object.curve_hatch"
-    bl_label = "CrossHatch curve"
+    bl_label = "CrossHatch Curve"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     angle: FloatProperty(
-        name="angle",
+        name="Angle",
         default=0,
         min=-pi/2,
         max=pi/2,
@@ -63,7 +63,7 @@ class CamCurveHatch(Operator):
         subtype="ANGLE",
     )
     distance: FloatProperty(
-        name="spacing",
+        name="Spacing",
         default=0.015,
         min=0,
         max=3.0,
@@ -87,7 +87,7 @@ class CamCurveHatch(Operator):
         unit="LENGTH",
     )
     amount: IntProperty(
-        name="amount",
+        name="Amount",
         default=10,
         min=1,
         max=10000,
@@ -101,14 +101,14 @@ class CamCurveHatch(Operator):
         default=False,
     )
     contour_separate: BoolProperty(
-        name="Contour separate",
+        name="Contour Separate",
         default=False,
     )
     pocket_type: EnumProperty(
-        name='Type pocket',
+        name='Type Pocket',
         items=(
-            ('BOUNDS', 'makes a bounds rectangle', 'makes a bounding square'),
-            ('POCKET', 'Pocket', 'makes a pocket inside a closed loop')
+            ('BOUNDS', 'Makes a bounds rectangle', 'Makes a bounding square'),
+            ('POCKET', 'Pocket', 'Makes a pocket inside a closed loop')
         ),
         description='Type of pocket',
         default='BOUNDS',
@@ -217,9 +217,9 @@ class CamCurveHatch(Operator):
 
 
 class CamCurvePlate(Operator):
-    """perform generates rounded plate with mounting holes"""  # by Alain Pelletier Sept 2021
+    """Perform Generates Rounded Plate with Mounting Holes"""  # by Alain Pelletier Sept 2021
     bl_idname = "object.curve_plate"
-    bl_label = "Sign plate"
+    bl_label = "Sign Plate"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     radius: FloatProperty(
@@ -231,7 +231,7 @@ class CamCurvePlate(Operator):
         unit="LENGTH",
     )
     width: FloatProperty(
-        name="Width of plate",
+        name="Width of Plate",
         default=0.3048,
         min=0,
         max=3.0,
@@ -239,7 +239,7 @@ class CamCurvePlate(Operator):
         unit="LENGTH",
     )
     height: FloatProperty(
-        name="Height of plate",
+        name="Height of Plate",
         default=0.457,
         min=0,
         max=3.0,
@@ -247,7 +247,7 @@ class CamCurvePlate(Operator):
         unit="LENGTH",
     )
     hole_diameter: FloatProperty(
-        name="Hole diameter",
+        name="Hole Diameter",
         default=0.01,
         min=0,
         max=3.0,
@@ -263,7 +263,7 @@ class CamCurvePlate(Operator):
         unit="LENGTH",
     )
     hole_vdist: FloatProperty(
-        name="Hole Vert distance",
+        name="Hole Vert Distance",
         default=0.400,
         min=0,
         max=3.0,
@@ -271,7 +271,7 @@ class CamCurvePlate(Operator):
         unit="LENGTH",
     )
     hole_hdist: FloatProperty(
-        name="Hole horiz distance",
+        name="Hole Horiz Distance",
         default=0,
         min=0,
         max=3.0,
@@ -279,19 +279,19 @@ class CamCurvePlate(Operator):
         unit="LENGTH",
     )
     hole_hamount: IntProperty(
-        name="Hole horiz amount",
+        name="Hole Horiz Amount",
         default=1,
         min=0,
         max=50,
     )
     resolution: IntProperty(
-        name="Spline resolution",
+        name="Spline Resolution",
         default=50,
         min=3,
         max=150,
     )
     plate_type: EnumProperty(
-        name='Type plate',
+        name='Type Plate',
         items=(
             ('ROUNDED', 'Rounded corner', 'Makes a rounded corner plate'),
             ('COVE', 'Cove corner',
@@ -492,13 +492,13 @@ class CamCurvePlate(Operator):
 
 
 class CamCurveFlatCone(Operator):
-    """perform generates rounded plate with mounting holes"""  # by Alain Pelletier Sept 2021
+    """Perform Generates Rounded Plate with Mounting Holes"""  # by Alain Pelletier Sept 2021
     bl_idname = "object.curve_flat_cone"
-    bl_label = "Cone flat calculator"
+    bl_label = "Cone Flat Calculator"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     small_d: FloatProperty(
-        name="small diameter",
+        name="Small Diameter",
         default=.025,
         min=0,
         max=0.1,
@@ -506,7 +506,7 @@ class CamCurveFlatCone(Operator):
         unit="LENGTH",
     )
     large_d: FloatProperty(
-        name="large diameter",
+        name="Large Diameter",
         default=0.3048,
         min=0,
         max=3.0,
@@ -514,7 +514,7 @@ class CamCurveFlatCone(Operator):
         unit="LENGTH",
     )
     height: FloatProperty(
-        name="Height of cone",
+        name="Height of Cone",
         default=0.457,
         min=0,
         max=3.0,
@@ -522,7 +522,7 @@ class CamCurveFlatCone(Operator):
         unit="LENGTH",
     )
     tab: FloatProperty(
-        name="tab witdh",
+        name="Tab Witdh",
         default=0.01,
         min=0,
         max=0.100,
@@ -530,7 +530,7 @@ class CamCurveFlatCone(Operator):
         unit="LENGTH",
     )
     intake: FloatProperty(
-        name="intake diameter",
+        name="Intake Diameter",
         default=0,
         min=0,
         max=0.200,
@@ -538,7 +538,7 @@ class CamCurveFlatCone(Operator):
         unit="LENGTH",
     )
     intake_skew: FloatProperty(
-        name="intake_skew",
+        name="Intake Skew",
         default=1,
         min=0.1,
         max=4,
@@ -589,13 +589,13 @@ class CamCurveFlatCone(Operator):
 
 
 class CamCurveMortise(Operator):
-    """Generates mortise along a curve"""  # by Alain Pelletier December 2021
+    """Generates Mortise Along a Curve"""  # by Alain Pelletier December 2021
     bl_idname = "object.curve_mortise"
     bl_label = "Mortise"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     finger_size: BoolProperty(
-        name="kurf bending only",
+        name="Kurf Bending only",
         default=False,
     )
     finger_size: FloatProperty(
@@ -615,7 +615,7 @@ class CamCurveMortise(Operator):
         unit="LENGTH",
     )
     finger_tolerance: FloatProperty(
-        name="Finger play room",
+        name="Finger Play Room",
         default=0.000045,
         min=0,
         max=0.003,
@@ -623,28 +623,28 @@ class CamCurveMortise(Operator):
         unit="LENGTH",
     )
     plate_thickness: FloatProperty(
-        name="Drawer plate thickness",
+        name="Drawer Plate Thickness",
         default=0.00477,
         min=0.001,
         max=3.0,
         unit="LENGTH",
     )
     side_height: FloatProperty(
-        name="side height",
+        name="Side Height",
         default=0.05,
         min=0.001,
         max=3.0,
         unit="LENGTH",
     )
     flex_pocket: FloatProperty(
-        name="Flex pocket",
+        name="Flex Pocket",
         default=0.004,
         min=0.000,
         max=1.0,
         unit="LENGTH",
     )
     top_bottom: BoolProperty(
-        name="Side Top & bottom fingers",
+        name="Side Top & Bottom Fingers",
         default=True,
     )
     opencurve: BoolProperty(
@@ -652,7 +652,7 @@ class CamCurveMortise(Operator):
         default=False,
     )
     adaptive: FloatProperty(
-        name="Adaptive angle threshold",
+        name="Adaptive Angle Threshold",
         default=0.0,
         min=0.000,
         max=2,
@@ -660,7 +660,7 @@ class CamCurveMortise(Operator):
         unit="ROTATION",
     )
     double_adaptive: BoolProperty(
-        name="Double adaptive Pockets",
+        name="Double Adaptive Pockets",
         default=False,
     )
 
@@ -732,7 +732,7 @@ class CamCurveMortise(Operator):
 
 
 class CamCurveInterlock(Operator):
-    """Generates interlock along a curve"""  # by Alain Pelletier December 2021
+    """Generates Interlock Along a Curve"""  # by Alain Pelletier December 2021
     bl_idname = "object.curve_interlock"
     bl_label = "Interlock"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
@@ -746,7 +746,7 @@ class CamCurveInterlock(Operator):
         unit="LENGTH",
     )
     finger_tolerance: FloatProperty(
-        name="Finger play room",
+        name="Finger Play Room",
         default=0.000045,
         min=0,
         max=0.003,
@@ -754,7 +754,7 @@ class CamCurveInterlock(Operator):
         unit="LENGTH",
     )
     plate_thickness: FloatProperty(
-        name="Plate thickness",
+        name="Plate Thickness",
         default=0.00477,
         min=0.001,
         max=3.0,
@@ -765,11 +765,11 @@ class CamCurveInterlock(Operator):
         default=False,
     )
     interlock_type: EnumProperty(
-        name='Type of interlock',
+        name='Type of Interlock',
         items=(
-            ('TWIST', 'Twist', 'Iterlock requires 1/4 turn twist'),
+            ('TWIST', 'Twist', 'Interlock requires 1/4 turn twist'),
             ('GROOVE', 'Groove', 'Simple sliding groove'),
-            ('PUZZLE', 'Puzzle interlock', 'puzzle good for flat joints')
+            ('PUZZLE', 'Puzzle Interlock', 'Puzzle good for flat joints')
         ),
         description='Type of interlock',
         default='GROOVE',
@@ -781,7 +781,7 @@ class CamCurveInterlock(Operator):
         max=100,
     )
     tangent_angle: FloatProperty(
-        name="Tangent deviation",
+        name="Tangent Deviation",
         default=0.0,
         min=0.000,
         max=2,
@@ -789,7 +789,7 @@ class CamCurveInterlock(Operator):
         unit="ROTATION",
     )
     fixed_angle: FloatProperty(
-        name="fixed angle",
+        name="Fixed Angle",
         default=0.0,
         min=0.000,
         max=2,
@@ -852,7 +852,7 @@ class CamCurveInterlock(Operator):
 
 
 class CamCurveDrawer(Operator):
-    """Generates drawers"""  # by Alain Pelletier December 2021 inspired by The Drawinator
+    """Generates Drawers"""  # by Alain Pelletier December 2021 inspired by The Drawinator
     bl_idname = "object.curve_drawer"
     bl_label = "Drawer"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
@@ -866,7 +866,7 @@ class CamCurveDrawer(Operator):
         unit="LENGTH",
     )
     width: FloatProperty(
-        name="Width of Drawer",
+        name="Drawer Width",
         default=0.125,
         min=0,
         max=3.0,
@@ -874,7 +874,7 @@ class CamCurveDrawer(Operator):
         unit="LENGTH",
     )
     height: FloatProperty(
-        name="Height of drawer",
+        name="Drawer Height",
         default=0.07,
         min=0,
         max=3.0,
@@ -890,7 +890,7 @@ class CamCurveDrawer(Operator):
         unit="LENGTH",
     )
     finger_tolerance: FloatProperty(
-        name="Finger play room",
+        name="Finger Play Room",
         default=0.000045,
         min=0,
         max=0.003,
@@ -898,7 +898,7 @@ class CamCurveDrawer(Operator):
         unit="LENGTH",
     )
     finger_inset: FloatProperty(
-        name="Finger inset",
+        name="Finger Inset",
         default=0.0,
         min=0.0,
         max=0.01,
@@ -906,7 +906,7 @@ class CamCurveDrawer(Operator):
         unit="LENGTH",
     )
     drawer_plate_thickness: FloatProperty(
-        name="Drawer plate thickness",
+        name="Drawer Plate Thickness",
         default=0.00477,
         min=0.001,
         max=3.0,
@@ -914,7 +914,7 @@ class CamCurveDrawer(Operator):
         unit="LENGTH",
     )
     drawer_hole_diameter: FloatProperty(
-        name="Drawer hole diameter",
+        name="Drawer Hole Diameter",
         default=0.02,
         min=0.00001,
         max=0.5,
@@ -922,7 +922,7 @@ class CamCurveDrawer(Operator):
         unit="LENGTH",
     )
     drawer_hole_offset: FloatProperty(
-        name="Drawer hole offset",
+        name="Drawer Hole Offset",
         default=0.0,
         min=-0.5,
         max=0.5,
@@ -930,11 +930,11 @@ class CamCurveDrawer(Operator):
         unit="LENGTH",
     )
     overcut: BoolProperty(
-        name="Add overcut",
+        name="Add Overcut",
         default=False,
     )
     overcut_diameter: FloatProperty(
-        name="Overcut toool Diameter",
+        name="Overcut Tool Diameter",
         default=0.003175,
         min=-0.001,
         max=0.5,
@@ -1066,13 +1066,13 @@ class CamCurveDrawer(Operator):
 
 
 class CamCurvePuzzle(Operator):
-    """Generates Puzzle joints and interlocks"""  # by Alain Pelletier December 2021
+    """Generates Puzzle Joints and Interlocks"""  # by Alain Pelletier December 2021
     bl_idname = "object.curve_puzzle"
-    bl_label = "Puzzle joints"
+    bl_label = "Puzzle Joints"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     diameter: FloatProperty(
-        name="tool diameter",
+        name="Tool Diameter",
         default=0.003175,
         min=0.001,
         max=3.0,
@@ -1080,7 +1080,7 @@ class CamCurvePuzzle(Operator):
         unit="LENGTH",
     )
     finger_tolerance: FloatProperty(
-        name="Finger play room",
+        name="Finger Play Room",
         default=0.00005,
         min=0,
         max=0.003,
@@ -1094,7 +1094,7 @@ class CamCurvePuzzle(Operator):
         max=100,
     )
     stem_size: IntProperty(
-        name="size of the stem",
+        name="Size of the Stem",
         default=2,
         min=1,
         max=200,
@@ -1108,7 +1108,7 @@ class CamCurvePuzzle(Operator):
         unit="LENGTH",
     )
     height: FloatProperty(
-        name="height or thickness",
+        name="Height or Thickness",
         default=0.025,
         min=0.005,
         max=3.0,
@@ -1117,7 +1117,7 @@ class CamCurvePuzzle(Operator):
     )
 
     angle: FloatProperty(
-        name="angle A",
+        name="Angle A",
         default=pi/4,
         min=-10,
         max=10,
@@ -1125,7 +1125,7 @@ class CamCurvePuzzle(Operator):
         unit="ROTATION",
     )
     angleb: FloatProperty(
-        name="angle B",
+        name="Angle B",
         default=pi/4,
         min=-10,
         max=10,
@@ -1143,7 +1143,7 @@ class CamCurvePuzzle(Operator):
     )
 
     interlock_type: EnumProperty(
-        name='Type of shape',
+        name='Type of Shape',
         items=(
             ('JOINT', 'Joint', 'Puzzle Joint interlock'),
             ('BAR', 'Bar', 'Bar interlock'),
@@ -1161,7 +1161,7 @@ class CamCurvePuzzle(Operator):
         default='CURVET',
     )
     gender: EnumProperty(
-        name='Type gender',
+        name='Type Gender',
         items=(
             ('MF', 'Male-Receptacle', 'Male and receptacle'),
             ('F', 'Receptacle only', 'Receptacle'),
@@ -1171,7 +1171,7 @@ class CamCurvePuzzle(Operator):
         default='MF',
     )
     base_gender: EnumProperty(
-        name='Base gender',
+        name='Base Gender',
         items=(
             ('MF', 'Male - Receptacle', 'Male - Receptacle'),
             ('F', 'Receptacle', 'Receptacle'),
@@ -1181,7 +1181,7 @@ class CamCurvePuzzle(Operator):
         default='M',
     )
     multiangle_gender: EnumProperty(
-        name='Multiangle gender',
+        name='Multiangle Gender',
         items=(
             ('MMF', 'Male Male Receptacle', 'M M F'),
             ('MFF', 'Male Receptacle Receptacle', 'M F F')
@@ -1208,38 +1208,38 @@ class CamCurvePuzzle(Operator):
         unit="LENGTH",
     )
     twist_percent: FloatProperty(
-        name="Twist neck",
+        name="Twist Neck",
         default=0.3,
         min=0.1,
         max=0.9,
         precision=4,
     )
     twist_keep: BoolProperty(
-        name="keep Twist holes",
+        name="Keep Twist Holes",
         default=False,
     )
     twist_line: BoolProperty(
-        name="Add Twist to bar",
+        name="Add Twist to Bar",
         default=False,
     )
     twist_line_amount: IntProperty(
-        name="amount of separators",
+        name="Amount of Separators",
         default=2,
         min=1,
         max=600,
     )
     twist_separator: BoolProperty(
-        name="Add Twist separator",
+        name="Add Twist Separator",
         default=False,
     )
     twist_separator_amount: IntProperty(
-        name="amount of separators",
+        name="Amount of Separators",
         default=2,
         min=2,
         max=600,
     )
     twist_separator_spacing: FloatProperty(
-        name="Separator spacing",
+        name="Separator Spacing",
         default=0.025,
         min=-0.004,
         max=1.0,
@@ -1247,7 +1247,7 @@ class CamCurvePuzzle(Operator):
         unit="LENGTH",
     )
     twist_separator_edge_distance: FloatProperty(
-        name="Separator edge distance",
+        name="Separator Edge Distance",
         default=0.01,
         min=0.0005,
         max=0.1,
@@ -1255,29 +1255,29 @@ class CamCurvePuzzle(Operator):
         unit="LENGTH",
     )
     tile_x_amount: IntProperty(
-        name="amount of x fingers",
+        name="Amount of X Fingers",
         default=2,
         min=1,
         max=600,
     )
     tile_y_amount: IntProperty(
-        name="amount of y fingers",
+        name="Amount of Y Fingers",
         default=2,
         min=1,
         max=600,
     )
     interlock_amount: IntProperty(
-        name="Interlock amount on curve",
+        name="Interlock Amount on Curve",
         default=2,
         min=0,
         max=200,
     )
     overcut: BoolProperty(
-        name="Add overcut",
+        name="Add Overcut",
         default=False,
     )
     overcut_diameter: FloatProperty(
-        name="Overcut toool Diameter",
+        name="Overcut Tool Diameter",
         default=0.003175,
         min=-0.001,
         max=0.5,
@@ -1459,7 +1459,7 @@ class CamCurvePuzzle(Operator):
 
 
 class CamCurveGear(Operator):
-    """Generates involute Gears // version 1.1 by Leemon Baird, 2011, Leemon@Leemon.com
+    """Generates Involute Gears // version 1.1 by Leemon Baird, 2011, Leemon@Leemon.com
     http://www.thingiverse.com/thing:5505"""  # ported by Alain Pelletier January 2022
 
     bl_idname = "object.curve_gear"
@@ -1467,7 +1467,7 @@ class CamCurveGear(Operator):
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     tooth_spacing: FloatProperty(
-        name="distance per tooth",
+        name="Distance per Tooth",
         default=0.010,
         min=0.001,
         max=1.0,
@@ -1475,19 +1475,19 @@ class CamCurveGear(Operator):
         unit="LENGTH",
     )
     tooth_amount: IntProperty(
-        name="Amount of teeth",
+        name="Amount of Teeth",
         default=7,
         min=4,
     )
 
     spoke_amount: IntProperty(
-        name="Amount of spokes",
+        name="Amount of Spokes",
         default=4,
         min=0,
     )
 
     hole_diameter: FloatProperty(
-        name="Hole diameter",
+        name="Hole Diameter",
         default=0.003175,
         min=0,
         max=3.0,
@@ -1495,7 +1495,7 @@ class CamCurveGear(Operator):
         unit="LENGTH",
     )
     rim_size: FloatProperty(
-        name="Rim size",
+        name="Rim Size",
         default=0.003175,
         min=0,
         max=3.0,
@@ -1503,7 +1503,7 @@ class CamCurveGear(Operator):
         unit="LENGTH",
     )
     hub_diameter: FloatProperty(
-        name="Hub diameter",
+        name="Hub Diameter",
         default=0.005,
         min=0,
         max=3.0,
@@ -1544,14 +1544,14 @@ class CamCurveGear(Operator):
         unit="LENGTH",
     )
     rack_tooth_per_hole: IntProperty(
-        name="teeth per mounting hole",
+        name="Teeth per Mounting Hole",
         default=7,
         min=2,
     )
     gear_type: EnumProperty(
-        name='Type of gear',
+        name='Type of Gear',
         items=(
-            ('PINION', 'Pinion', 'circular gear'),
+            ('PINION', 'Pinion', 'Circular Gear'),
             ('RACK', 'Rack', 'Straight Rack')
         ),
         description='Type of gear',

--- a/scripts/addons/cam/curvecamequation.py
+++ b/scripts/addons/cam/curvecamequation.py
@@ -35,14 +35,14 @@ from . import parametric
 
 
 class CamSineCurve(bpy.types.Operator):
-    """Object sine """  # by Alain Pelletier april 2021
+    """Object Sine """  # by Alain Pelletier april 2021
     bl_idname = "object.sine"
-    bl_label = "Create Periodic wave"
+    bl_label = "Create Periodic Wave"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     #    zstring: StringProperty(name="Z equation", description="Equation for z=F(u,v)", default="0.05*sin(2*pi*4*t)" )
     axis: EnumProperty(
-        name="displacement axis",
+        name="Displacement Axis",
         items=(
             ('XY', 'Y to displace X axis', 'Y constant; X sine displacement'),
             ('YX', 'X to displace Y axis', 'X constant; Y sine displacement'),
@@ -78,7 +78,7 @@ class CamSineCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     beatperiod: FloatProperty(
-        name="Beat Period offset",
+        name="Beat Period Offset",
         default=0.0,
         min=0.0,
         max=100,
@@ -86,7 +86,7 @@ class CamSineCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     shift: FloatProperty(
-        name="phase shift",
+        name="Phase Shift",
         default=0,
         min=-360,
         max=360,
@@ -94,7 +94,7 @@ class CamSineCurve(bpy.types.Operator):
         unit="ROTATION",
     )
     offset: FloatProperty(
-        name="offset",
+        name="Offset",
         default=0,
         min=-
         1.0,
@@ -103,13 +103,13 @@ class CamSineCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     iteration: IntProperty(
-        name="iteration",
+        name="Iteration",
         default=100,
         min=50,
         max=2000,
     )
     maxt: FloatProperty(
-        name="Wave ends at x",
+        name="Wave Ends at X",
         default=0.5,
         min=-3.0,
         max=3,
@@ -117,7 +117,7 @@ class CamSineCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     mint: FloatProperty(
-        name="Wave starts at x",
+        name="Wave Starts at X",
         default=0,
         min=-3.0,
         max=3,
@@ -125,7 +125,7 @@ class CamSineCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     wave_distance: FloatProperty(
-        name="distance between multiple waves",
+        name="Distance Between Multiple Waves",
         default=0.0,
         min=0.0,
         max=100,
@@ -133,7 +133,7 @@ class CamSineCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     wave_angle_offset: FloatProperty(
-        name="angle offset for multiple waves",
+        name="Angle Offset for Multiple Waves",
         default=pi/2,
         min=-200*pi,
         max=200*pi,
@@ -141,7 +141,7 @@ class CamSineCurve(bpy.types.Operator):
         unit="ROTATION",
     )
     wave_amount: IntProperty(
-        name="amount of multiple waves",
+        name="Amount of Multiple Waves",
         default=1,
         min=1,
         max=2000,
@@ -195,7 +195,7 @@ class CamSineCurve(bpy.types.Operator):
 class CamLissajousCurve(bpy.types.Operator):
     """Lissajous """  # by Alain Pelletier april 2021
     bl_idname = "object.lissajous"
-    bl_label = "Create Lissajous figure"
+    bl_label = "Create Lissajous Figure"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     amplitude_A: FloatProperty(
@@ -264,7 +264,7 @@ class CamLissajousCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     shift: FloatProperty(
-        name="phase shift",
+        name="Phase Shift",
         default=0,
         min=-360,
         max=360,
@@ -273,13 +273,13 @@ class CamLissajousCurve(bpy.types.Operator):
     )
 
     iteration: IntProperty(
-        name="iteration",
+        name="Iteration",
         default=500,
         min=50,
         max=10000,
     )
     maxt: FloatProperty(
-        name="Wave ends at x",
+        name="Wave Ends at X",
         default=11,
         min=-3.0,
         max=1000000,
@@ -287,7 +287,7 @@ class CamLissajousCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     mint: FloatProperty(
-        name="Wave starts at x",
+        name="Wave Starts at X",
         default=0,
         min=-10.0,
         max=3,
@@ -330,20 +330,20 @@ class CamLissajousCurve(bpy.types.Operator):
 
 
 class CamHypotrochoidCurve(bpy.types.Operator):
-    """hypotrochoid """  # by Alain Pelletier april 2021
+    """Hypotrochoid """  # by Alain Pelletier april 2021
     bl_idname = "object.hypotrochoid"
-    bl_label = "Create Spirograph type figure"
+    bl_label = "Create Spirograph Type Figure"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     typecurve: EnumProperty(
-        name="type of curve",
+        name="Type of Curve",
         items=(
-            ('hypo', 'Hypotrochoid', 'inside ring'),
-            ('epi', 'Epicycloid', 'outside inner ring')
+            ('hypo', 'Hypotrochoid', 'Inside ring'),
+            ('epi', 'Epicycloid', 'Outside inner ring')
         ),
     )
     R: FloatProperty(
-        name="Big circle radius",
+        name="Big Circle Radius",
         default=0.25,
         min=0.001,
         max=100,
@@ -351,7 +351,7 @@ class CamHypotrochoidCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     r: FloatProperty(
-        name="Small circle radius",
+        name="Small Circle Radius",
         default=0.18,
         min=0.0001,
         max=100,
@@ -359,7 +359,7 @@ class CamHypotrochoidCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     d: FloatProperty(
-        name="distance from center of interior circle",
+        name="Distance from Center of Interior Circle",
         default=0.050,
         min=0,
         max=100,
@@ -367,7 +367,7 @@ class CamHypotrochoidCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     dip: FloatProperty(
-        name="variable depth from center",
+        name="Variable Depth from Center",
         default=0.00,
         min=-100,
         max=100,
@@ -424,35 +424,35 @@ class CamHypotrochoidCurve(bpy.types.Operator):
 
 
 class CamCustomCurve(bpy.types.Operator):
-    """Object customCurve """  # by Alain Pelletier april 2021
+    """Object Custom Curve """  # by Alain Pelletier april 2021
     bl_idname = "object.customcurve"
-    bl_label = "Create custom curve"
+    bl_label = "Create Custom Curve"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     xstring: StringProperty(
-        name="X equation",
+        name="X Equation",
         description="Equation x=F(t)",
         default="t",
     )
     ystring: StringProperty(
-        name="Y equation",
+        name="Y Equation",
         description="Equation y=F(t)",
         default="0",
     )
     zstring: StringProperty(
-        name="Z equation",
+        name="Z Equation",
         description="Equation z=F(t)",
         default="0.05*sin(2*pi*4*t)",
     )
 
     iteration: IntProperty(
-        name="iteration",
+        name="Iteration",
         default=100,
         min=50,
         max=2000,
     )
     maxt: FloatProperty(
-        name="Wave ends at x",
+        name="Wave Ends at X",
         default=0.5,
         min=-3.0,
         max=10,
@@ -460,7 +460,7 @@ class CamCustomCurve(bpy.types.Operator):
         unit="LENGTH",
     )
     mint: FloatProperty(
-        name="Wave starts at x",
+        name="Wave Starts at X",
         default=0,
         min=-3.0,
         max=3,

--- a/scripts/addons/cam/curvecamtools.py
+++ b/scripts/addons/cam/curvecamtools.py
@@ -46,19 +46,19 @@ from . import (
 
 # boolean operations for curve objects
 class CamCurveBoolean(Operator):
-    """perform Boolean operation on two or more curves"""
+    """Perform Boolean Operation on Two or More Curves"""
     bl_idname = "object.curve_boolean"
     bl_label = "Curve Boolean"
     bl_options = {'REGISTER', 'UNDO'}
 
     boolean_type: EnumProperty(
-        name='type',
+        name='Type',
         items=(
             ('UNION', 'Union', ''),
             ('DIFFERENCE', 'Difference', ''),
             ('INTERSECT', 'Intersect', '')
         ),
-        description='boolean type',
+        description='Boolean type',
         default='UNION'
     )
 
@@ -76,7 +76,7 @@ class CamCurveBoolean(Operator):
 
 
 class CamCurveConvexHull(Operator):
-    """perform hull operation on single or multiple curves"""  # by Alain Pelletier april 2021
+    """Perform Hull Operation on Single or Multiple Curves"""  # by Alain Pelletier april 2021
     bl_idname = "object.convex_hull"
     bl_label = "Convex Hull"
     bl_options = {'REGISTER', 'UNDO'}
@@ -92,13 +92,13 @@ class CamCurveConvexHull(Operator):
 
 # intarsion or joints
 class CamCurveIntarsion(Operator):
-    """makes curve cuttable both inside and outside, for intarsion and joints"""
+    """Makes Curve Cuttable Both Inside and Outside, for Intarsion and Joints"""
     bl_idname = "object.curve_intarsion"
     bl_label = "Intarsion"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     diameter: FloatProperty(
-        name="cutter diameter",
+        name="Cutter Diameter",
         default=.001,
         min=0,
         max=0.025,
@@ -106,7 +106,7 @@ class CamCurveIntarsion(Operator):
         unit="LENGTH",
     )
     tolerance: FloatProperty(
-        name="cutout Tolerance",
+        name="Cutout Tolerance",
         default=.0001,
         min=0,
         max=0.005,
@@ -114,7 +114,7 @@ class CamCurveIntarsion(Operator):
         unit="LENGTH",
     )
     backlight: FloatProperty(
-        name="Backlight seat",
+        name="Backlight Seat",
         default=0.000,
         min=0,
         max=0.010,
@@ -122,7 +122,7 @@ class CamCurveIntarsion(Operator):
         unit="LENGTH",
     )
     perimeter_cut: FloatProperty(
-        name="Perimeter cut offset",
+        name="Perimeter Cut Offset",
         default=0.000,
         min=0,
         max=0.100,
@@ -130,7 +130,7 @@ class CamCurveIntarsion(Operator):
         unit="LENGTH",
     )
     base_thickness: FloatProperty(
-        name="Base material thickness",
+        name="Base Material Thickness",
         default=0.000,
         min=0,
         max=0.100,
@@ -138,7 +138,7 @@ class CamCurveIntarsion(Operator):
         unit="LENGTH",
     )
     intarsion_thickness: FloatProperty(
-        name="Intarsion material thickness",
+        name="Intarsion Material Thickness",
         default=0.000,
         min=0,
         max=0.100,
@@ -146,7 +146,7 @@ class CamCurveIntarsion(Operator):
         unit="LENGTH",
     )
     backlight_depth_from_top: FloatProperty(
-        name="Backlight well depth",
+        name="Backlight Well Depth",
         default=0.000,
         min=0,
         max=0.100,
@@ -214,13 +214,13 @@ class CamCurveIntarsion(Operator):
 
 # intarsion or joints
 class CamCurveOvercuts(Operator):
-    """Adds overcuts for slots"""
+    """Adds Overcuts for Slots"""
     bl_idname = "object.curve_overcuts"
-    bl_label = "Add Overcuts"
+    bl_label = "Add Overcuts - A"
     bl_options = {'REGISTER', 'UNDO'}
 
     diameter: FloatProperty(
-        name="diameter",
+        name="Diameter",
         default=.003175,
         min=0,
         max=100,
@@ -228,7 +228,7 @@ class CamCurveOvercuts(Operator):
         unit="LENGTH",
     )
     threshold: FloatProperty(
-        name="threshold",
+        name="Threshold",
         default=pi / 2 * .99,
         min=-3.14,
         max=3.14,
@@ -237,7 +237,7 @@ class CamCurveOvercuts(Operator):
         unit="ROTATION",
     )
     do_outer: BoolProperty(
-        name="Outer polygons",
+        name="Outer Polygons",
         default=True,
     )
     invert: BoolProperty(
@@ -322,13 +322,13 @@ class CamCurveOvercuts(Operator):
 
 # Overcut type B
 class CamCurveOvercutsB(Operator):
-    """Adds overcuts for slots"""
+    """Adds Overcuts for Slots"""
     bl_idname = "object.curve_overcuts_b"
-    bl_label = "Add Overcuts-B"
+    bl_label = "Add Overcuts - B"
     bl_options = {'REGISTER', 'UNDO'}
 
     diameter: FloatProperty(
-        name="Tool diameter",
+        name="Tool Diameter",
         default=.003175,
         description='Tool bit diameter used in cut operation',
         min=0,
@@ -337,7 +337,7 @@ class CamCurveOvercutsB(Operator):
         unit="LENGTH",
     )
     style: EnumProperty(
-        name="style",
+        name="Style",
         items=(
             ('OPEDGE', 'opposite edge',
              'place corner overcuts on opposite edges'),
@@ -359,7 +359,7 @@ class CamCurveOvercutsB(Operator):
         unit="ROTATION",
     )
     do_outer: BoolProperty(
-        name="Include outer curve",
+        name="Include Outer Curve",
         description='Include the outer curve if there are curves inside',
         default=True,
     )
@@ -369,7 +369,7 @@ class CamCurveOvercutsB(Operator):
         default=True,
     )
     otherEdge: BoolProperty(
-        name="other edge",
+        name="Other Edge",
         description='change to the other edge for the overcut to be on',
         default=False,
     )
@@ -592,9 +592,9 @@ class CamCurveOvercutsB(Operator):
 
 
 class CamCurveRemoveDoubles(Operator):
-    """curve remove doubles"""
+    """Curve Remove Doubles"""
     bl_idname = "object.curve_remove_doubles"
-    bl_label = "C-Remove doubles"
+    bl_label = "Remove Curve Doubles"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -604,11 +604,11 @@ class CamCurveRemoveDoubles(Operator):
     def execute(self, context):
         obs = bpy.context.selected_objects
         #bpy.context.object.data.dimensions = '3D'
-        bpy.context.object.data.resolution_u = 32
+        #bpy.context.object.data.resolution_u = 32
         for ob in obs:
             bpy.context.view_layer.objects.active = ob
             if bpy.context.mode == 'OBJECT':
-               bpy.ops.object.editmode_toggle()
+                bpy.ops.object.editmode_toggle()
             bpy.ops.curve.select_all()
             bpy.ops.curve.decimate(ratio=1)
             bpy.ops.curve.remove_double(distance=0.0001)
@@ -618,13 +618,13 @@ class CamCurveRemoveDoubles(Operator):
 
 
 class CamMeshGetPockets(Operator):
-    """Detect pockets in a mesh and extract them as curves"""
+    """Detect Pockets in a Mesh and Extract Them as Curves"""
     bl_idname = "object.mesh_get_pockets"
-    bl_label = "Get pocket surfaces"
+    bl_label = "Get Pocket Surfaces"
     bl_options = {'REGISTER', 'UNDO'}
 
     threshold: FloatProperty(
-        name="horizontal threshold",
+        name="Horizontal Threshold",
         description="How horizontal the surface must be for a pocket: "
         "1.0 perfectly flat, 0.0 is any orientation",
         default=.99,
@@ -633,8 +633,8 @@ class CamMeshGetPockets(Operator):
         precision=4,
     )
     zlimit: FloatProperty(
-        name="z limit",
-        description="maximum z height considered for pocket operation, "
+        name="Z Limit",
+        description="Maximum z height considered for pocket operation, "
         "default is 0.0",
         default=0.0,
         min=-1000.0,
@@ -729,13 +729,13 @@ class CamMeshGetPockets(Operator):
 
 # this operator finds the silhouette of objects(meshes, curves just get converted) and offsets it.
 class CamOffsetSilhouete(Operator):
-    """Curve offset operation """
+    """Curve Offset Operation """
     bl_idname = "object.silhouete_offset"
-    bl_label = "Silhouete offset"
+    bl_label = "Silhouette Offset"
     bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
     offset: FloatProperty(
-        name="offset",
+        name="Offset",
         default=.003,
         min=-100,
         max=100,
@@ -751,7 +751,7 @@ class CamOffsetSilhouete(Operator):
         unit="LENGTH",
     )
     style: EnumProperty(
-        name="type of curve",
+        name="Type of Curve",
         items=(
             ('1', 'Round', ''),
             ('2', 'Mitre', ''),
@@ -759,7 +759,7 @@ class CamOffsetSilhouete(Operator):
         ),
     )
     opencurve: BoolProperty(
-        name="Dialate open curve",
+        name="Dialate Open Curve",
         default=False,
     )
 
@@ -804,9 +804,9 @@ class CamOffsetSilhouete(Operator):
 
 # Finds object silhouette, usefull for meshes, since with curves it's not needed.
 class CamObjectSilhouete(Operator):
-    """Object silhouete """
+    """Object Silhouette"""
     bl_idname = "object.silhouete"
-    bl_label = "Object silhouete"
+    bl_label = "Object Silhouette"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod

--- a/scripts/addons/cam/engine.py
+++ b/scripts/addons/cam/engine.py
@@ -25,7 +25,7 @@ from .ui_panels.slice import CAM_SLICE_Panel
 
 class BLENDERCAM_ENGINE(RenderEngine):
     bl_idname = "BLENDERCAM_RENDER"
-    bl_label = "Cam"
+    bl_label = "BlenderCAM"
     bl_use_eevee_viewport = True
 
 

--- a/scripts/addons/cam/gcodeimportparser.py
+++ b/scripts/addons/cam/gcodeimportparser.py
@@ -46,7 +46,7 @@ def import_gcode(context, filepath):
         model.draw(split_layers=False)
 
     now = time.time()
-    print("importing Gcode took ", round(now - then, 1), "seconds")
+    print("Importing Gcode Took ", round(now - then, 1), "Seconds")
 
     return {'FINISHED'}
 

--- a/scripts/addons/cam/gcodepath.py
+++ b/scripts/addons/cam/gcodepath.py
@@ -91,9 +91,9 @@ def pointonline(a, b, c, tolerence):
 
 
 def exportGcodePath(filename, vertslist, operations):
-    """exports gcode with the heeks nc adopted library."""
+    """Exports G-code with the Heeks NC Adopted Library."""
     print("EXPORT")
-    progress('exporting gcode file')
+    progress('Exporting G-code File')
     t = time.time()
     s = bpy.context.scene
     m = s.cam_machine
@@ -113,7 +113,7 @@ def exportGcodePath(filename, vertslist, operations):
         if totops > m.split_limit:
             split = True
             filesnum = ceil(totops / m.split_limit)
-            print('file will be separated into %i files' % filesnum)
+            print('File Will Be Separated Into %i Files' % filesnum)
     print('1')
 
     basefilename = bpy.data.filepath[:-
@@ -203,7 +203,7 @@ def exportGcodePath(filename, vertslist, operations):
         # start program
         c.program_begin(0, filename)
         c.flush_nc()
-        c.comment('G-code generated with BlenderCAM and NC library')
+        c.comment('G-code Generated with BlenderCAM and NC library')
         # absolute coordinates
         c.absolute()
 
@@ -571,7 +571,7 @@ async def getPath(context, operation):  # should do all path calculations.
             pr.enable()
             await getPath3axis(context, operation)
             pr.disable()
-            pr.dump_stats(time.strftime("blendercam_%Y%m%d_%H%M.prof"))
+            pr.dump_stats(time.strftime("BlenderCAM_%Y%m%d_%H%M.prof"))
         else:
             await getPath3axis(context, operation)
 
@@ -600,8 +600,8 @@ async def getPath(context, operation):  # should do all path calculations.
 
 
 def getChangeData(o):
-    """this is a function to check if object props have changed,
-    to see if image updates are needed in the image based method"""
+    """This Is a Function to Check if Object Props Have Changed,
+    to See if Image Updates Are Needed in the Image Based Method"""
     changedata = ''
     obs = []
     if o.geometry_source == 'OBJECT':
@@ -628,8 +628,8 @@ def checkMemoryLimit(o):
     if res > limit:
         ratio = (res / limit)
         o.optimisation.pixsize = o.optimisation.pixsize * sqrt(ratio)
-        o.info.warnings += f"Memory limit: sampling resolution reduced to {o.optimisation.pixsize:.2e}\n"
-        print('changing sampling resolution to %f' % o.optimisation.pixsize)
+        o.info.warnings += f"Memory limit: Sampling Resolution Reduced to {o.optimisation.pixsize:.2e}\n"
+        print('Changing Sampling Resolution to %f' % o.optimisation.pixsize)
 
 
 # this is the main function.

--- a/scripts/addons/cam/image_utils.py
+++ b/scripts/addons/cam/image_utils.py
@@ -160,7 +160,7 @@ def _offset_inner_loop(y1, y2, cutterArrayNan, cwidth, sourceArray, width, heigh
 
 
 async def offsetArea(o, samples):
-    """ offsets the whole image with the cutter + skin offsets """
+    """ Offsets the Whole Image with the Cutter + Skin Offsets """
     if o.update_offsetimage_tag:
         minx, miny, minz, maxx, maxy, maxz = o.min.x, o.min.y, o.min.z, o.max.x, o.max.y, o.max.z
 
@@ -192,7 +192,7 @@ async def offsetArea(o, samples):
             await progress_async('offset depth image', int((y2 * 100) / comparearea.shape[1]))
         o.offset_image[m: width - cwidth + m, m:height - cwidth + m] = comparearea
 
-        print('\nOffset image time ' + str(time.time() - t))
+        print('\nOffset Image Time ' + str(time.time() - t))
 
         o.update_offsetimage_tag = False
     return o.offset_image
@@ -205,9 +205,9 @@ def dilateAr(ar, cycles):
 
 
 def getOffsetImageCavities(o, i):  # for pencil operation mainly
-    """detects areas in the offset image which are 'cavities' - the curvature changes."""
+    """Detects Areas in the Offset Image Which Are 'cavities' - the Curvature Changes."""
     # i=numpy.logical_xor(lastislice , islice)
-    progress('detect corners in the offset image')
+    progress('Detect Corners in the Offset Image')
     vertical = i[:-2, 1:-1] - i[1:-1, 1:-1] - o.pencil_threshold > i[1:-1, 1:-1] - i[2:, 1:-1]
     horizontal = i[1:-1, :-2] - i[1:-1, 1:-1] - o.pencil_threshold > i[1:-1, 1:-1] - i[1:-1, 2:]
     # if bpy.app.debug_value==2:
@@ -267,7 +267,7 @@ def imageEdgeSearch_online(o, ar, zimage):
 
         if perc != int(100 - 100 * totpix / startpix):
             perc = int(100 - 100 * totpix / startpix)
-            progress('pencil path searching', perc)
+            progress('Pencil Path Searching', perc)
         # progress('simulation ',int(100*i/l))
         success = False
         testangulardistance = 0  # distance from initial direction in the list of direction
@@ -286,7 +286,7 @@ def imageEdgeSearch_online(o, ar, zimage):
                 last_direction = test_direction
                 ar[xs, ys] = False
                 if 0:
-                    print('success')
+                    print('Success')
                     print(xs, ys, testlength, testangle)
                     print(lastvect)
                     print(testvect)
@@ -1100,7 +1100,7 @@ def _restore_render_settings(pairs, properties):
 
 def renderSampleImage(o):
     t = time.time()
-    progress('getting zbuffer')
+    progress('Getting Z-Buffer')
     # print(o.zbuffer_image)
     o.update_offsetimage_tag = True
     if o.geometry_source == 'OBJECT' or o.geometry_source == 'COLLECTION':
@@ -1221,7 +1221,7 @@ def renderSampleImage(o):
                 if backup_settings is not None:
                     _restore_render_settings(SETTINGS_TO_BACKUP, backup_settings)
                 else:
-                    print("Failed to backup scene settings")
+                    print("Failed to Backup Scene Settings")
 
             i = bpy.data.images.load(iname)
             bpy.context.scene.render.engine = 'BLENDERCAM_RENDER'
@@ -1248,7 +1248,7 @@ def renderSampleImage(o):
         #o.offset_image.resize(ex - sx + 2 * o.borderwidth, ey - sy + 2 * o.borderwidth)
 
         o.optimisation.pixsize = o.source_image_size_x / i.size[0]
-        progress('pixel size in the image source', o.optimisation.pixsize)
+        progress('Pixel Size in the Image Source', o.optimisation.pixsize)
 
         rawimage = imagetonumpy(i)
         maxa = numpy.max(rawimage)
@@ -1304,7 +1304,7 @@ async def prepareArea(o):
     iname = getCachePath(o) + '_off.exr'
 
     if not o.update_offsetimage_tag:
-        progress('loading offset image')
+        progress('Loading Offset Image')
         try:
             o.offset_image = imagetonumpy(bpy.data.images.load(iname))
 
@@ -1390,7 +1390,7 @@ def getCutterArray(operation, pixsize):
         # print(cutob.scale)
         vstart = Vector((0, 0, -10))
         vend = Vector((0, 0, 10))
-        print('sampling custom cutter')
+        print('Sampling Custom Cutter')
         maxz = -1
         for a in range(0, res):
             vstart.x = (a + 0.5 - m) * ps * scale

--- a/scripts/addons/cam/joinery.py
+++ b/scripts/addons/cam/joinery.py
@@ -311,7 +311,7 @@ def fixed_finger(loop, loop_length, finger_size, finger_thick, finger_tolerance,
     old_mortise_angle = 0
     distance = finger_size / 2
     j = 0
-    print("joinery loop length", round(loop_length * 1000), "mm")
+    print("Joinery Loop Length", round(loop_length * 1000), "mm")
     for i, p in enumerate(coords):
         if i == 0:
             p_start = p
@@ -527,8 +527,8 @@ def distributed_interlock(loop, loop_length, finger_depth, finger_thick, finger_
         end_distance = loop_length
 
     j = 0
-    print("joinery loop length", round(loop_length * 1000), "mm")
-    print("distance between joints", round(spacing * 1000), "mm")
+    print("Joinery Loop Length", round(loop_length * 1000), "mm")
+    print("Distance Between Joints", round(spacing * 1000), "mm")
 
     for i, p in enumerate(coords):
         if i == 0:

--- a/scripts/addons/cam/machine_settings.py
+++ b/scripts/addons/cam/machine_settings.py
@@ -15,17 +15,17 @@ class machineSettings(PropertyGroup):
     """stores all data for machines"""
     # name = StringProperty(name="Machine Name", default="Machine")
     post_processor: EnumProperty(
-        name='Post processor',
+        name='Post Processor',
         items=(
-            ('ISO', 'Iso', 'exports standardized gcode ISO 6983 (RS-274)'),
-            ('MACH3', 'Mach3', 'default mach3'),
+            ('ISO', 'Iso', 'Exports standardized gcode ISO 6983 (RS-274)'),
+            ('MACH3', 'Mach3', 'Default mach3'),
             ('EMC', 'LinuxCNC - EMC2',
              'Linux based CNC control software - formally EMC2'),
             ('FADAL', 'Fadal', 'Fadal VMC'),
             ('GRBL', 'grbl',
-             'optimized gcode for grbl firmware on Arduino with cnc shield'),
-            ('HEIDENHAIN', 'Heidenhain', 'heidenhain'),
-            ('HEIDENHAIN530', 'Heidenhain530', 'heidenhain530'),
+             'Optimized gcode for grbl firmware on Arduino with cnc shield'),
+            ('HEIDENHAIN', 'Heidenhain', 'Heidenhain'),
+            ('HEIDENHAIN530', 'Heidenhain530', 'Heidenhain530'),
             ('TNC151', 'Heidenhain TNC151',
              'Post Processor for the Heidenhain TNC151 machine'),
             ('SIEGKX1', 'Sieg KX1', 'Sieg KX1'),
@@ -37,19 +37,19 @@ class machineSettings(PropertyGroup):
             ('SHOPBOT MTC', 'ShopBot MTC', 'ShopBot MTC'),
             ('LYNX_OTTER_O', 'Lynx Otter o', 'Lynx Otter o')
         ),
-        description='Post processor',
+        description='Post Processor',
         default='MACH3',
     )
     # units = EnumProperty(name='Units', items = (('IMPERIAL', ''))
     # position definitions:
     use_position_definitions: BoolProperty(
-        name="Use position definitions",
+        name="Use Position Definitions",
         description="Define own positions for op start, "
         "toolchange, ending position",
         default=False,
     )
     starting_position: FloatVectorProperty(
-        name='Start position',
+        name='Start Position',
         default=(0, 0, 0),
         unit='LENGTH',
         precision=constants.PRECISION,
@@ -57,7 +57,7 @@ class machineSettings(PropertyGroup):
         update=updateMachine,
     )
     mtc_position: FloatVectorProperty(
-        name='MTC position',
+        name='MTC Position',
         default=(0, 0, 0),
         unit='LENGTH',
         precision=constants.PRECISION,
@@ -65,7 +65,7 @@ class machineSettings(PropertyGroup):
         update=updateMachine,
     )
     ending_position: FloatVectorProperty(
-        name='End position',
+        name='End Position',
         default=(0, 0, 0),
         unit='LENGTH',
         precision=constants.PRECISION,
@@ -82,7 +82,7 @@ class machineSettings(PropertyGroup):
         update=updateMachine,
     )
     feedrate_min: FloatProperty(
-        name="Feedrate minimum /min",
+        name="Feedrate Minimum /min",
         default=0.0,
         min=0.00001,
         max=320000,
@@ -90,7 +90,7 @@ class machineSettings(PropertyGroup):
         unit='LENGTH',
     )
     feedrate_max: FloatProperty(
-        name="Feedrate maximum /min",
+        name="Feedrate Maximum /min",
         default=2,
         min=0.00001,
         max=320000,
@@ -98,7 +98,7 @@ class machineSettings(PropertyGroup):
         unit='LENGTH',
     )
     feedrate_default: FloatProperty(
-        name="Feedrate default /min",
+        name="Feedrate Default /min",
         default=1.5,
         min=0.00001,
         max=320000,
@@ -106,7 +106,7 @@ class machineSettings(PropertyGroup):
         unit='LENGTH',
     )
     hourly_rate: FloatProperty(
-        name="Price per hour",
+        name="Price per Hour",
         default=100,
         min=0.005,
         precision=2,
@@ -115,28 +115,28 @@ class machineSettings(PropertyGroup):
     # UNSUPPORTED:
 
     spindle_min: FloatProperty(
-        name="Spindle speed minimum RPM",
+        name="Spindle Speed Minimum RPM",
         default=5000,
         min=0.00001,
         max=320000,
         precision=1,
     )
     spindle_max: FloatProperty(
-        name="Spindle speed maximum RPM",
+        name="Spindle Speed Maximum RPM",
         default=30000,
         min=0.00001,
         max=320000,
         precision=1,
     )
     spindle_default: FloatProperty(
-        name="Spindle speed default RPM",
+        name="Spindle Speed Default RPM",
         default=15000,
         min=0.00001,
         max=320000,
         precision=1,
     )
     spindle_start_time: FloatProperty(
-        name="Spindle start delay seconds",
+        name="Spindle Start Delay Seconds",
         description='Wait for the spindle to start spinning before starting '
         'the feeds , in seconds',
         default=0,
@@ -146,23 +146,23 @@ class machineSettings(PropertyGroup):
     )
 
     axis4: BoolProperty(
-        name="#4th axis",
+        name="#4th Axis",
         description="Machine has 4th axis",
         default=0,
     )
     axis5: BoolProperty(
-        name="#5th axis",
+        name="#5th Axis",
         description="Machine has 5th axis",
         default=0,
     )
 
     eval_splitting: BoolProperty(
-        name="Split files",
-        description="split gcode file with large number of operations",
+        name="Split Files",
+        description="Split gcode file with large number of operations",
         default=True,
     )  # split large files
     split_limit: IntProperty(
-        name="Operations per file",
+        name="Operations per File",
         description="Split files with larger number of operations than this",
         min=1000,
         max=20000000,
@@ -178,7 +178,7 @@ class machineSettings(PropertyGroup):
     #     default='X', update = updateOffsetImage)
 
     collet_size: FloatProperty(
-        name="#Collet size",
+        name="#Collet Size",
         description="Collet size for collision detection",
         default=33,
         min=0.00001,
@@ -191,38 +191,38 @@ class machineSettings(PropertyGroup):
     # post processor options
 
     output_block_numbers: BoolProperty(
-        name="output block numbers",
-        description="output block numbers ie N10 at start of line",
+        name="Output Block Numbers",
+        description="Output block numbers ie N10 at start of line",
         default=False,
     )
 
     start_block_number: IntProperty(
-        name="start block number",
-        description="the starting block number ie 10",
+        name="Start Block Number",
+        description="The starting block number ie 10",
         default=10,
     )
 
     block_number_increment: IntProperty(
-        name="block number increment",
-        description="how much the block number should "
+        name="Block Number Increment",
+        description="How much the block number should "
         "increment for the next line",
         default=10,
     )
 
     output_tool_definitions: BoolProperty(
-        name="output tool definitions",
-        description="output tool definitions",
+        name="Output Tool Definitions",
+        description="Output tool definitions",
         default=True,
     )
 
     output_tool_change: BoolProperty(
-        name="output tool change commands",
-        description="output tool change commands ie: Tn M06",
+        name="Output Tool Change Commands",
+        description="Output tool change commands ie: Tn M06",
         default=True,
     )
 
     output_g43_on_tool_change: BoolProperty(
-        name="output G43 on tool change",
-        description="output G43 on tool change line",
+        name="Output G43 on Tool Change",
+        description="Output G43 on tool change line",
         default=False,
     )

--- a/scripts/addons/cam/opencamlib/oclSample.py
+++ b/scripts/addons/cam/opencamlib/oclSample.py
@@ -43,7 +43,7 @@ def get_oclSTL(operation):
         # FIXME needs to work with collections
     if not found_mesh:
         raise CamException(
-            "This operation requires a mesh or curve object or equivalent (e.g. text, volume).")
+            "This Operation Requires a Mesh or Curve Object or Equivalent (e.g. Text, Volume).")
     return oclSTL
 
 
@@ -78,7 +78,7 @@ async def ocl_sample(operation, chunks, use_cached_mesh=False):
         cutter = ocl.BullCutter((op_cutter_diameter + operation.skin * 2) *
                                 1000, operation.bull_corner_radius*1000, cutter_length)
     else:
-        print("Cutter unsupported: {0}\n".format(op_cutter_type))
+        print("Cutter Unsupported: {0}\n".format(op_cutter_type))
         quit()
 
     bdc = ocl.BatchDropCutter()
@@ -93,7 +93,7 @@ async def ocl_sample(operation, chunks, use_cached_mesh=False):
     for chunk in chunks:
         for coord in chunk.get_points_np():
             bdc.appendPoint(ocl.CLPoint(coord[0] * 1000, coord[1] * 1000, op_minz * 1000))
-    await progress_async("OpenCAMLib sampling")
+    await progress_async("OpenCAMLib Sampling")
     bdc.run()
 
     cl_points = bdc.getCLPoints()

--- a/scripts/addons/cam/ops.py
+++ b/scripts/addons/cam/ops.py
@@ -68,7 +68,7 @@ class threadCom:  # object passed to threads to read background process stdout i
 
 
 def threadread(tcom):
-    """reads stdout of background process, done this way to have it non-blocking"""
+    """Reads Stdout of Background Process, Done This Way to Have It Non-blocking"""
     inline = tcom.proc.stdout.readline()
     inline = str(inline)
     s = inline.find('progress{')
@@ -79,7 +79,7 @@ def threadread(tcom):
 
 @bpy.app.handlers.persistent
 def timer_update(context):
-    """monitoring of background processes"""
+    """Monitoring of Background Processes"""
     text = ''
     s = bpy.context.scene
     if hasattr(bpy.ops.object.calculate_cam_paths_background.__class__, 'cam_processes'):
@@ -114,9 +114,9 @@ def timer_update(context):
 
 
 class PathsBackground(Operator):
-    """calculate CAM paths in background. File has to be saved before."""
+    """Calculate CAM Paths in Background. File Has to Be Saved Before."""
     bl_idname = "object.calculate_cam_paths_background"
-    bl_label = "Calculate CAM paths in background"
+    bl_label = "Calculate CAM Paths in Background"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
@@ -149,9 +149,9 @@ class PathsBackground(Operator):
 
 
 class KillPathsBackground(Operator):
-    """Remove CAM path processes in background."""
+    """Remove CAM Path Processes in Background."""
     bl_idname = "object.kill_calculate_cam_paths_background"
-    bl_label = "Kill background computation of an operation"
+    bl_label = "Kill Background Computation of an Operation"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
@@ -201,8 +201,8 @@ async def _calc_path(operator, context):
     # check for free movement height < maxz and return with error
     if(o.movement.free_height < o.maxz):
         operator.report({'ERROR_INVALID_INPUT'},
-                        "Free movement height is less than Operation depth start \n correct and try again.")
-        progress_async("Operation can't be performed, see warnings for info")
+                        "Free Movement Height Is Less than Operation Depth Start \n Correct and Try Again.")
+        progress_async("Operation Can't Be Performed, See Warnings for Info")
         return {'FINISHED', False}
 
     if o.computing:
@@ -214,7 +214,7 @@ async def _calc_path(operator, context):
         o.movement.parallel_step_back = False
     try:
         await gcodepath.getPath(context, o)
-        print("Got path okay")
+        print("Got Path Okay")
     except CamException as e:
         traceback.print_tb(e.__traceback__)
         error_str = "\n".join(textwrap.wrap(str(e), width=80))
@@ -235,9 +235,9 @@ async def _calc_path(operator, context):
 
 
 class CalculatePath(Operator, AsyncOperatorMixin):
-    """calculate CAM paths"""
+    """Calculate CAM Paths"""
     bl_idname = "object.calculate_cam_path"
-    bl_label = "Calculate CAM paths"
+    bl_label = "Calculate CAM Paths"
     bl_options = {'REGISTER', 'UNDO', 'BLOCKING'}
 
     @classmethod
@@ -256,16 +256,16 @@ class CalculatePath(Operator, AsyncOperatorMixin):
 
 
 class PathsAll(Operator):
-    """calculate all CAM paths"""
+    """Calculate All CAM Paths"""
     bl_idname = "object.calculate_cam_paths_all"
-    bl_label = "Calculate all CAM paths"
+    bl_label = "Calculate All CAM Paths"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
         i = 0
         for o in bpy.context.scene.cam_operations:
             bpy.context.scene.cam_active_operation = i
-            print('\nCalculating path :' + o.name)
+            print('\nCalculating Path :' + o.name)
             print('\n')
             bpy.ops.object.calculate_cam_paths_background()
             i += 1
@@ -279,9 +279,9 @@ class PathsAll(Operator):
 
 
 class CamPackObjects(Operator):
-    """calculate all CAM paths"""
+    """Calculate All CAM Paths"""
     bl_idname = "object.cam_pack_objects"
-    bl_label = "Pack curves on sheet"
+    bl_label = "Pack Curves on Sheet"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
@@ -296,10 +296,10 @@ class CamPackObjects(Operator):
 
 
 class CamSliceObjects(Operator):
-    """Slice a mesh object horizontally"""
+    """Slice a Mesh Object Horizontally"""
     # warning, this is a separate and neglected feature, it's a mess - by now it just slices up the object.
     bl_idname = "object.cam_slice_objects"
-    bl_label = "Slice object - usefull for lasercut puzzles e.t.c."
+    bl_label = "Slice Object - Useful for Lasercut Puzzles etc"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
@@ -313,7 +313,7 @@ class CamSliceObjects(Operator):
 
 
 def getChainOperations(chain):
-    """return chain operations, currently chain object can't store operations directly due to blender limitations"""
+    """Return Chain Operations, Currently Chain Object Can't Store Operations Directly Due to Blender Limitations"""
     chop = []
     for cho in chain.operations:
         for so in bpy.context.scene.cam_operations:
@@ -323,9 +323,9 @@ def getChainOperations(chain):
 
 
 class PathsChain(Operator, AsyncOperatorMixin):
-    """calculate a chain and export the gcode alltogether. """
+    """Calculate a Chain and Export the G-code Alltogether. """
     bl_idname = "object.calculate_cam_paths_chain"
-    bl_label = "Calculate CAM paths in current chain and export chain gcode"
+    bl_label = "Calculate CAM Paths in Current Chain and Export Chain G-code"
     bl_options = {'REGISTER', 'UNDO', 'BLOCKING'}
 
     @classmethod
@@ -344,11 +344,11 @@ class PathsChain(Operator, AsyncOperatorMixin):
             for i in range(0, len(chainops)):
                 s.cam_active_operation = s.cam_operations.find(
                     chainops[i].name)
-                self.report({'INFO'}, f"Calculating path: {chainops[i].name}")
+                self.report({'INFO'}, f"Calculating Path: {chainops[i].name}")
                 result, success = await _calc_path(self, context)
                 if not success and 'FINISHED' in result:
                     self.report(
-                        {'ERROR'}, f"Couldn't calculate path: {chainops[i].name}")
+                        {'ERROR'}, f"Couldn't Calculate Path: {chainops[i].name}")
         except Exception as e:
             print("FAIL", e)
             traceback.print_tb(e.__traceback__)
@@ -362,9 +362,9 @@ class PathsChain(Operator, AsyncOperatorMixin):
 
 
 class PathExportChain(Operator):
-    """calculate a chain and export the gcode alltogether. """
+    """Calculate a Chain and Export the G-code Together."""
     bl_idname = "object.cam_export_paths_chain"
-    bl_label = "Export CAM paths in current chain as gcode"
+    bl_label = "Export CAM Paths in Current Chain as G-code"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -390,9 +390,9 @@ class PathExportChain(Operator):
 
 
 class PathExport(Operator):
-    """Export gcode. Can be used only when the path object is present"""
+    """Export G-code. Can Be Used only when the Path Object Is Present"""
     bl_idname = "object.cam_export"
-    bl_label = "Export operation gcode"
+    bl_label = "Export Operation G-code"
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
@@ -409,11 +409,11 @@ class PathExport(Operator):
 
 
 class CAMSimulate(Operator, AsyncOperatorMixin):
-    """simulate CAM operation
-    this is performed by: creating an image, painting Z depth of the brush substractively.
-    Works only for some operations, can not be used for 4-5 axis."""
+    """Simulate CAM Operation
+    This Is Performed by: Creating an Image, Painting Z Depth of the Brush Subtractively.
+    Works only for Some Operations, Can Not Be Used for 4-5 Axis."""
     bl_idname = "object.cam_simulate"
-    bl_label = "CAM simulation"
+    bl_label = "CAM Simulation"
     bl_options = {'REGISTER', 'UNDO', 'BLOCKING'}
 
     operation: StringProperty(
@@ -434,7 +434,7 @@ class CAMSimulate(Operator, AsyncOperatorMixin):
             except AsyncCancelledException as e:
                 return {'CANCELLED'}
         else:
-            self.report({'ERROR'}, 'no computed path to simulate')
+            self.report({'ERROR'}, 'No Computed Path to Simulate')
             return {'FINISHED'}
         return {'FINISHED'}
 
@@ -445,10 +445,10 @@ class CAMSimulate(Operator, AsyncOperatorMixin):
 
 
 class CAMSimulateChain(Operator, AsyncOperatorMixin):
-    """simulate CAM chain, compared to single op simulation just writes into one image and thus enables
-    to see how ops work together."""
+    """Simulate CAM Chain, Compared to Single Op Simulation Just Writes Into One Image and Thus Enables
+    to See how Ops Work Together."""
     bl_idname = "object.cam_simulate_chain"
-    bl_label = "CAM simulation"
+    bl_label = "CAM Simulation"
     bl_options = {'REGISTER', 'UNDO', 'BLOCKING'}
 
     @classmethod
@@ -490,9 +490,9 @@ class CAMSimulateChain(Operator, AsyncOperatorMixin):
 
 
 class CamChainAdd(Operator):
-    """Add new CAM chain"""
+    """Add New CAM Chain"""
     bl_idname = "scene.cam_chain_add"
-    bl_label = "Add new CAM chain"
+    bl_label = "Add New CAM Chain"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -513,9 +513,9 @@ class CamChainAdd(Operator):
 
 
 class CamChainRemove(Operator):
-    """Remove  CAM chain"""
+    """Remove CAM Chain"""
     bl_idname = "scene.cam_chain_remove"
-    bl_label = "Remove CAM chain"
+    bl_label = "Remove CAM Chain"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -531,9 +531,9 @@ class CamChainRemove(Operator):
 
 
 class CamChainOperationAdd(Operator):
-    """Add operation to chain"""
+    """Add Operation to Chain"""
     bl_idname = "scene.cam_chain_operation_add"
-    bl_label = "Add operation to chain"
+    bl_label = "Add Operation to Chain"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -551,9 +551,9 @@ class CamChainOperationAdd(Operator):
 
 
 class CamChainOperationUp(Operator):
-    """Add operation to chain"""
+    """Add Operation to Chain"""
     bl_idname = "scene.cam_chain_operation_up"
-    bl_label = "Add operation to chain"
+    bl_label = "Add Operation to Chain"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -571,9 +571,9 @@ class CamChainOperationUp(Operator):
 
 
 class CamChainOperationDown(Operator):
-    """Add operation to chain"""
+    """Add Operation to Chain"""
     bl_idname = "scene.cam_chain_operation_down"
-    bl_label = "Add operation to chain"
+    bl_label = "Add Operation to Chain"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -591,9 +591,9 @@ class CamChainOperationDown(Operator):
 
 
 class CamChainOperationRemove(Operator):
-    """Remove operation from chain"""
+    """Remove Operation from Chain"""
     bl_idname = "scene.cam_chain_operation_remove"
-    bl_label = "Remove operation from chain"
+    bl_label = "Remove Operation from Chain"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -611,7 +611,7 @@ class CamChainOperationRemove(Operator):
 
 
 def fixUnits():
-    """Sets up units for blender CAM"""
+    """Sets up Units for BlenderCAM"""
     s = bpy.context.scene
 
     s.unit_settings.system_rotation = 'DEGREES'
@@ -621,9 +621,9 @@ def fixUnits():
 
 
 class CamOperationAdd(Operator):
-    """Add new CAM operation"""
+    """Add New CAM Operation"""
     bl_idname = "scene.cam_operation_add"
-    bl_label = "Add new CAM operation"
+    bl_label = "Add New CAM Operation"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -637,7 +637,7 @@ class CamOperationAdd(Operator):
         ob = bpy.context.active_object
         if ob is None:
             self.report({'ERROR_INVALID_INPUT'},
-                        "Please add an object to base the operation on.")
+                        "Please Add an Object to Base the Operation on.")
             return {'CANCELLED'}
 
         minx, miny, minz, maxx, maxy, maxz = getBoundsWorldspace([ob])
@@ -658,9 +658,9 @@ class CamOperationAdd(Operator):
 
 
 class CamOperationCopy(Operator):
-    """Copy CAM operation"""
+    """Copy CAM Operation"""
     bl_idname = "scene.cam_operation_copy"
-    bl_label = "Copy active CAM operation"
+    bl_label = "Copy Active CAM Operation"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -709,9 +709,9 @@ class CamOperationCopy(Operator):
 
 
 class CamOperationRemove(Operator):
-    """Remove CAM operation"""
+    """Remove CAM Operation"""
     bl_idname = "scene.cam_operation_remove"
-    bl_label = "Remove CAM operation"
+    bl_label = "Remove CAM Operation"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -744,18 +744,18 @@ class CamOperationRemove(Operator):
 
 # move cam operation in the list up or down
 class CamOperationMove(Operator):
-    """Move CAM operation"""
+    """Move CAM Operation"""
     bl_idname = "scene.cam_operation_move"
-    bl_label = "Move CAM operation in list"
+    bl_label = "Move CAM Operation in List"
     bl_options = {'REGISTER', 'UNDO'}
 
     direction: EnumProperty(
-        name='direction',
+        name='Direction',
         items=(
             ('UP', 'Up', ''),
             ('DOWN', 'Down', '')
         ),
-        description='direction',
+        description='Direction',
         default='DOWN',
     )
 
@@ -781,9 +781,9 @@ class CamOperationMove(Operator):
 
 
 class CamOrientationAdd(Operator):
-    """Add orientation to cam operation, for multiaxis operations"""
+    """Add Orientation to CAM Operation, for Multiaxis Operations"""
     bl_idname = "scene.cam_orientation_add"
-    bl_label = "Add orientation"
+    bl_label = "Add Orientation"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -808,9 +808,9 @@ class CamOrientationAdd(Operator):
 
 
 class CamBridgesAdd(Operator):
-    """Add bridge objects to curve"""
+    """Add Bridge Objects to Curve"""
     bl_idname = "scene.cam_bridges_add"
-    bl_label = "Add bridges"
+    bl_label = "Add Bridges / Tabs"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod

--- a/scripts/addons/cam/pack.py
+++ b/scripts/addons/cam/pack.py
@@ -218,7 +218,7 @@ class PackObjectsSettings(PropertyGroup):
     """stores all data for machines"""
 
     sheet_fill_direction: EnumProperty(
-        name="Fill direction",
+        name="Fill Direction",
         items=(
             ("X", "X", "Fills sheet in X axis direction"),
             ("Y", "Y", "Fills sheet in Y axis direction"),
@@ -227,7 +227,7 @@ class PackObjectsSettings(PropertyGroup):
         default="Y",
     )
     sheet_x: FloatProperty(
-        name="X size",
+        name="X Size",
         description="Sheet size",
         min=0.001,
         max=10,
@@ -236,7 +236,7 @@ class PackObjectsSettings(PropertyGroup):
         unit="LENGTH",
     )
     sheet_y: FloatProperty(
-        name="Y size",
+        name="Y Size",
         description="Sheet size",
         min=0.001,
         max=10,
@@ -245,8 +245,8 @@ class PackObjectsSettings(PropertyGroup):
         unit="LENGTH",
     )
     distance: FloatProperty(
-        name="Minimum distance",
-        description="minimum distance between objects(should be "
+        name="Minimum Distance",
+        description="Minimum distance between objects(should be "
         "at least cutter diameter!)",
         min=0.001,
         max=10,
@@ -264,13 +264,13 @@ class PackObjectsSettings(PropertyGroup):
         unit="LENGTH",
     )
     rotate: BoolProperty(
-        name="enable rotation",
+        name="Enable Rotation",
         description="Enable rotation of elements",
         default=True,
     )
     rotate_angle: FloatProperty(
-        name="Placement Angle rotation step",
-        description="bigger rotation angle,faster placemant",
+        name="Placement Angle Rotation Step",
+        description="Bigger rotation angle, faster placemant",
         default=0.19635 * 4,
         min=pi / 180,
         max=pi,

--- a/scripts/addons/cam/pattern.py
+++ b/scripts/addons/cam/pattern.py
@@ -150,7 +150,7 @@ def getPathPatternParallel(o, angle):
 def getPathPattern(operation):
     o = operation
     t = time.time()
-    progress('building path pattern')
+    progress('Building Path Pattern')
     minx, miny, minz, maxx, maxy, maxz = o.min.x, o.min.y, o.min.z, o.max.x, o.max.y, o.max.z
 
     pathchunks = []
@@ -408,7 +408,7 @@ def getPathPattern(operation):
 def getPathPattern4axis(operation):
     o = operation
     t = time.time()
-    progress('building path pattern')
+    progress('Building Path Pattern')
     minx, miny, minz, maxx, maxy, maxz = o.min.x, o.min.y, o.min.z, o.max.x, o.max.y, o.max.z
     pathchunks = []
     zlevel = 1  # minz#this should do layers...

--- a/scripts/addons/cam/polygon_utils_cam.py
+++ b/scripts/addons/cam/polygon_utils_cam.py
@@ -73,7 +73,7 @@ def shapelyToMultipolygon(anydata):
         else:
             return sgeometry.MultiPolygon()
     else:
-        print(anydata.type, 'shapely conversion aborted')
+        print(anydata.type, 'Shapely Conversion Aborted')
         return sgeometry.MultiPolygon()
 
 

--- a/scripts/addons/cam/preferences.py
+++ b/scripts/addons/cam/preferences.py
@@ -15,17 +15,17 @@ class CamAddonPreferences(AddonPreferences):
     bl_idname = __package__
 
     op_preset_update: BoolProperty(
-        name="Have the Operation Presets been Updated",
+        name="Have the Operation Presets Been Updated",
         default=False,
     )
 
     experimental: BoolProperty(
-        name="Show experimental features",
+        name="Show Experimental Features",
         default=False,
     )
 
     update_source: StringProperty(
-        name="Source of updates for the addon",
+        name="Source of Updates for the Addon",
         description="This can be either a github repo link in which case "
         "it will download the latest release on there, "
         "or an api link like "
@@ -35,39 +35,39 @@ class CamAddonPreferences(AddonPreferences):
     )
 
     last_update_check: IntProperty(
-        name="Last update time",
+        name="Last Update Time",
         default=0,
     )
 
     last_commit_hash: StringProperty(
-        name="Hash of last commit from updater",
+        name="Hash of Last Commit from Updater",
         default="",
     )
 
     just_updated: BoolProperty(
-        name="Set to true on update or initial install",
+        name="Set to True on Update or Initial Install",
         default=True,
     )
 
     new_version_available: StringProperty(
-        name="Set to new version name if one is found",
+        name="Set to New Version Name if One Is Found",
         default="",
     )
 
     default_interface_level: EnumProperty(
-        name="Interface level in new file",
+        name="Interface Level in New File",
         description="Choose visible options",
         items=[
-            ("0", "Basic", "Only show essential options"),
-            ("1", "Advanced", "Show advanced options"),
-            ("2", "Complete", "Show all options"),
-            ("3", "Experimental", "Show experimental options"),
+            ("0", "Basic", "Only show Essential Options"),
+            ("1", "Advanced", "Show Advanced Options"),
+            ("2", "Complete", "Show All Options"),
+            ("3", "Experimental", "Show Experimental Options"),
         ],
         default="3",
     )
 
     default_machine_preset: StringProperty(
-        name="Machine preset in new file",
+        name="Machine Preset in New File",
         description="So that machine preset choice persists between files",
         default="",
     )
@@ -75,11 +75,11 @@ class CamAddonPreferences(AddonPreferences):
     def draw(self, context):
         layout = self.layout
         layout.label(
-            text="Use experimental features when you want to help development of Blender CAM:"
+            text="Use Experimental Features when you want to help development of BlenderCAM:"
         )
         layout.prop(self, "experimental")
         layout.prop(self, "update_source")
-        layout.label(text="Choose a preset update source")
+        layout.label(text="Choose a Preset Update Source")
 
         UPDATE_SOURCES = [
             (

--- a/scripts/addons/cam/preset_managers.py
+++ b/scripts/addons/cam/preset_managers.py
@@ -7,14 +7,14 @@ from bpy.types import (
 
 
 class CAM_CUTTER_MT_presets(Menu):
-    bl_label = "Cutter presets"
+    bl_label = "Cutter Presets"
     preset_subdir = "cam_cutters"
     preset_operator = "script.execute_preset"
     draw = Menu.draw_preset
 
 
 class CAM_MACHINE_MT_presets(Menu):
-    bl_label = "Machine presets"
+    bl_label = "Machine Presets"
     preset_subdir = "cam_machines"
     preset_operator = "script.execute_preset"
     draw = Menu.draw_preset
@@ -54,7 +54,7 @@ class AddPresetCamCutter(AddPresetBase, Operator):
 
 
 class CAM_OPERATION_MT_presets(Menu):
-    bl_label = "Operation presets"
+    bl_label = "Operation Presets"
     preset_subdir = "cam_operations"
     preset_operator = "script.execute_preset"
     draw = Menu.draw_preset

--- a/scripts/addons/cam/simple.py
+++ b/scripts/addons/cam/simple.py
@@ -71,7 +71,7 @@ def timingprint(tinf):
 
 
 def progress(text, n=None):
-    """function for reporting during the script, works for background operations in the header."""
+    """Function for Reporting During the Script, Works for Background Operations in the Header."""
     text = str(text)
     if n is None:
         n = ''
@@ -82,7 +82,7 @@ def progress(text, n=None):
 
 
 def activate(o):
-    """makes an object active, used many times in blender"""
+    """Makes an Object Active, Used Many Times in Blender"""
     s = bpy.context.scene
     bpy.ops.object.select_all(action='DESELECT')
     o.select_set(state=True)
@@ -91,18 +91,18 @@ def activate(o):
 
 
 def dist2d(v1, v2):
-    """distance between two points in 2d"""
+    """Distance Between Two Points in 2D"""
     return hypot((v1[0] - v2[0]), (v1[1] - v2[1]))
 
 
 def delob(ob):
-    """object deletion for multiple uses"""
+    """Object Deletion for Multiple Uses"""
     activate(ob)
     bpy.ops.object.delete(use_global=False)
 
 
 def dupliob(o, pos):
-    """helper function for visualising cutter positions in bullet simulation"""
+    """Helper Function for Visualising Cutter Positions in Bullet Simulation"""
     activate(o)
     bpy.ops.object.duplicate()
     s = 1.0 / BULLET_SCALE
@@ -123,7 +123,7 @@ def addToGroup(ob, groupname):
 
 
 def compare(v1, v2, vmiddle, e):
-    """comparison for optimisation of paths"""
+    """Comparison for Optimisation of Paths"""
     # e=0.0001
     v1 = Vector(v1)
     v2 = Vector(v2)
@@ -139,7 +139,7 @@ def compare(v1, v2, vmiddle, e):
 
 
 def isVerticalLimit(v1, v2, limit):
-    """test path segment on verticality threshold, for protect_vertical option"""
+    """Test Path Segment on Verticality Threshold, for protect_vertical Option"""
     z = abs(v1[2] - v2[2])
     # verticality=0.05
     # this will be better.

--- a/scripts/addons/cam/simulation.py
+++ b/scripts/addons/cam/simulation.py
@@ -98,7 +98,7 @@ def createSimulationObject(name, operations, i):
 
 
 async def doSimulation(name, operations):
-    """perform simulation of operations. Currently only for 3 axis"""
+    """Perform Simulation of Operations. Currently only for 3 Axis"""
     for o in operations:
         getOperationSources(o)
     limits = getBoundsMultiple(
@@ -296,8 +296,8 @@ async def generateSimulationImage(operations, limits):
 
 
 def simCutterSpot(xs, ys, z, cutterArray, si, getvolume=False):
-    """simulates a cutter cutting into stock, taking away the volume,
-    and optionally returning the volume that has been milled. This is now used for feedrate tweaking."""
+    """Simulates a Cutter Cutting Into Stock, Taking Away the Volume,
+    and Optionally Returning the Volume that Has Been Milled. This Is Now Used for Feedrate Tweaking."""
     m = int(cutterArray.shape[0] / 2)
     size = cutterArray.shape[0]
     # whole cutter in image there

--- a/scripts/addons/cam/slice.py
+++ b/scripts/addons/cam/slice.py
@@ -145,11 +145,11 @@ def sliceObject(ob):  # April 2020 Alain Pelletier
 
 
 class SliceObjectsSettings(PropertyGroup):
-    """stores all data for machines"""
+    """Stores All Data for Machines"""
 
     slice_distance: FloatProperty(
-        name="Slicing distance",
-        description="slices distance in z, should be most often "
+        name="Slicing Distance",
+        description="Slices distance in z, should be most often "
         "thickness of plywood sheet.",
         min=0.001,
         max=10,
@@ -158,17 +158,17 @@ class SliceObjectsSettings(PropertyGroup):
         unit="LENGTH",
     )
     slice_above0: BoolProperty(
-        name="Slice above 0",
+        name="Slice Above 0",
         description="only slice model above 0",
         default=False,
     )
     slice_3d: BoolProperty(
-        name="3d slice",
-        description="for 3d carving",
+        name="3D Slice",
+        description="For 3D carving",
         default=False,
     )
     indexes: BoolProperty(
-        name="add indexes",
-        description="adds index text of layer + index",
+        name="Add Indexes",
+        description="Adds index text of layer + index",
         default=True,
     )

--- a/scripts/addons/cam/strategy.py
+++ b/scripts/addons/cam/strategy.py
@@ -110,7 +110,7 @@ async def cutout(o):
         join = 2
     else:
         join = 1
-    print('operation: cutout')
+    print('Operation: Cutout')
     offset = True
     if o.cut_type == 'ONLINE' and o.onlycurves:  # is separate to allow open curves :)
         print('separate')
@@ -196,9 +196,9 @@ async def cutout(o):
     chunks = []
 
     if o.use_bridges:  # add bridges to chunks
-        print('using bridges')
+        print('Using Bridges')
         remove_multiple(o.name+'_cut_bridges')
-        print("old briddge cut removed")
+        print("Old Briddge Cut Removed")
 
         bridgeheight = min(o.max.z, o.min.z + abs(o.bridges_height))
 
@@ -209,7 +209,7 @@ async def cutout(o):
                 useBridges(chunk, o)
 
     if o.profile_start > 0:
-        print("cutout change profile start")
+        print("Cutout Change Profile Start")
         for chl in extendorder:
             chunk = chl[0]
             if chunk.closed:
@@ -217,7 +217,7 @@ async def cutout(o):
 
     # Lead in
     if o.lead_in > 0.0 or o.lead_out > 0:
-        print("cutout leadin")
+        print("Cutout Lead-in")
         for chl in extendorder:
             chunk = chl[0]
             if chunk.closed:
@@ -242,11 +242,11 @@ async def cutout(o):
 
 
 async def curve(o):
-    print('operation: curve')
+    print('Operation: Curve')
     pathSamples = []
     getOperationSources(o)
     if not o.onlycurves:
-        raise CamException("All objects must be curves for this operation.")
+        raise CamException("All Objects Must Be Curves for This Operation.")
 
     for ob in o.objects:
         # make the chunks from curve here
@@ -289,7 +289,7 @@ async def curve(o):
 
 
 async def proj_curve(s, o):
-    print('operation: projected curve')
+    print('Operation: Projected Curve')
     pathSamples = []
     chunks = []
     ob = bpy.data.objects[o.curve_object]
@@ -299,7 +299,7 @@ async def proj_curve(s, o):
 
     from cam import cam_chunk
     if targetCurve.type != 'CURVE':
-        raise CamException('Projection target and source have to be curve objects!')
+        raise CamException('Projection Target and Source Have to Be Curve Objects!')
 
     if 1:
         extend_up = 0.1
@@ -340,7 +340,7 @@ async def proj_curve(s, o):
 
 
 async def pocket(o):
-    print('operation: pocket')
+    print('Operation: Pocket')
     scene = bpy.context.scene
 
     remove_multiple("3D_poc")
@@ -358,11 +358,11 @@ async def pocket(o):
         c_offset = o.cutter_diameter / 2
 
     c_offset += o.skin  # add skin
-    print("cutter offset", c_offset)
+    print("Cutter Offset", c_offset)
 
     p = getObjectOutline(c_offset, o, False)
     approxn = (min(o.max.x - o.min.x, o.max.y - o.min.y) / o.dist_between_paths) / 2
-    print("approximative:" + str(approxn))
+    print("Approximative:" + str(approxn))
     print(o)
 
     i = 0
@@ -394,7 +394,7 @@ async def pocket(o):
         lastchunks = nchunks
 
         percent = int(i / approxn * 100)
-        progress('outlining polygons ', percent)
+        progress('Outlining Polygons ', percent)
         p = pnew
 
         i += 1
@@ -537,7 +537,7 @@ async def pocket(o):
 
 
 async def drill(o):
-    print('operation: Drill')
+    print('Operation: Drill')
     chunks = []
     for ob in o.objects:
         activate(ob)
@@ -631,7 +631,7 @@ async def drill(o):
 
 
 async def medial_axis(o):
-    print('operation: Medial Axis')
+    print('Operation: Medial Axis')
 
     remove_multiple("medialMesh")
 
@@ -660,7 +660,7 @@ async def medial_axis(o):
     elif o.cutter_type == 'BALLNOSE':
         maxdepth = - new_cutter_diameter / 2 - o.skin
     else:
-        raise CamException("Only Ballnose and V-carve cutters are supported for meial axis.")
+        raise CamException("Only Ballnose and V-carve Cutters Are Supported for Medial Axis.")
     # remember resolutions of curves, to refine them,
     # otherwise medial axis computation yields too many branches in curved parts
     resolutions_before = []
@@ -681,7 +681,7 @@ async def medial_axis(o):
         # just a multipolygon
         mpoly = polys
     else:
-        raise CamException("Failed getting object silhouette. Is input curve closed?")
+        raise CamException("Failed Getting Object Silhouette. Is Input Curve Closed?")
 
     mpoly_boundary = mpoly.boundary
     ipol = 0
@@ -700,19 +700,19 @@ async def medial_axis(o):
         # verts= points#[[vert.x, vert.y, vert.z] for vert in vertsPts]
         nDupli, nZcolinear = unique(verts)
         nVerts = len(verts)
-        print(str(nDupli) + " duplicates points ignored")
-        print(str(nZcolinear) + " z colinear points excluded")
+        print(str(nDupli) + " Duplicates Points Ignored")
+        print(str(nZcolinear) + " Z Colinear Points Excluded")
         if nVerts < 3:
-            print("Not enough points")
+            print("Not Enough Points")
             return {'FINISHED'}
         # Check colinear
         xValues = [pt[0] for pt in verts]
         yValues = [pt[1] for pt in verts]
         if checkEqual(xValues) or checkEqual(yValues):
-            print("Points are colinear")
+            print("Points Are Colinear")
             return {'FINISHED'}
         # Create diagram
-        print("Tesselation... (" + str(nVerts) + " points)")
+        print("Tesselation... (" + str(nVerts) + " Points)")
         xbuff, ybuff = 5, 5  # %
         zPosition = 0
         vertsPts = [Point(vert[0], vert[1], vert[2]) for vert in verts]
@@ -725,14 +725,14 @@ async def medial_axis(o):
         newIdx = 0
         vertr = []
         filteredPts = []
-        print('filter points')
+        print('Filter Points')
         ipts = 0
         for p in pts:
             ipts = ipts + 1
             if ipts % 500 == 0:
                 sys.stdout.write('\r')
                 # the exact output you're looking for:
-                prog_message = "points: " + str(ipts) + " / " + str(len(pts)) + " " + str(
+                prog_message = "Points: " + str(ipts) + " / " + str(len(pts)) + " " + str(
                     round(100 * ipts / len(pts))) + "%"
                 sys.stdout.write(prog_message)
                 sys.stdout.flush()
@@ -761,7 +761,7 @@ async def medial_axis(o):
                 filteredPts.append((p[0], p[1], z))
                 newIdx += 1
 
-        print('filter edges')
+        print('Filter Edges')
         filteredEdgs = []
         ledges = []
         for e in edgesIdx:
@@ -829,17 +829,17 @@ async def medial_axis(o):
 
 
 def getLayers(operation, startdepth, enddepth):
-    """returns a list of layers bounded by startdepth and enddepth
-       uses operation.stepdown to determine number of layers.
+    """Returns a List of Layers Bounded by Startdepth and Enddepth
+       Uses Operation.stepdown to Determine Number of Layers.
     """
     if startdepth < enddepth:
-        raise CamException("Start depth is lower than end depth. "
-                           "If you have set a custom depth end, it must be lower than depth start, "
-                           "and should usually be negative. Set this in the CAM Operation Area panel.")
+        raise CamException("Start Depth Is Lower than End Depth. "
+                           "if You Have Set a Custom Depth End, It Must Be Lower than Depth Start, "
+                           "and Should Usually Be Negative. Set This in the CAM Operation Area Panel.")
     if operation.use_layers:
         layers = []
         n = ceil((startdepth - enddepth) / operation.stepdown)
-        print("start " + str(startdepth) + " end " + str(enddepth) + " n " + str(n))
+        print("Start " + str(startdepth) + " End " + str(enddepth) + " n " + str(n))
 
         layerstart = operation.maxz
         for x in range(0, n):
@@ -856,7 +856,7 @@ def getLayers(operation, startdepth, enddepth):
 
 
 def chunksToMesh(chunks, o):
-    """convert sampled chunks to path, optimization of paths"""
+    """Convert Sampled Chunks to Path, Optimization of Paths"""
     t = time.time()
     s = bpy.context.scene
     m = s.cam_machine
@@ -888,7 +888,7 @@ def chunksToMesh(chunks, o):
                     nchunks.append(ch)
         chunks = nchunks
 
-    progress('building paths from chunks')
+    progress('Building Paths from Chunks')
     e = 0.0001
     lifted = True
 

--- a/scripts/addons/cam/testing.py
+++ b/scripts/addons/cam/testing.py
@@ -141,7 +141,7 @@ def testOperation(i):
     newresult = bpy.data.objects[o.path_object_name]
     origname = "test_cam_path_" + o.name
     if origname not in s.objects:
-        report += 'operation test has nothing to compare with, making the new result as comparable result.\n\n'
+        report += 'Operation Test Has Nothing to Compare with, Making the New Result as Comparable Result.\n\n'
         newresult.name = origname
     else:
         testresult = bpy.data.objects[origname]
@@ -149,7 +149,7 @@ def testOperation(i):
         m2 = newresult.data
         test_ok = True
         if len(m1.vertices) != len(m2.vertices):
-            report += "vertex counts don't match\n\n"
+            report += "Vertex Counts Don't Match\n\n"
             test_ok = False
         else:
             different_co_count = 0
@@ -159,12 +159,12 @@ def testOperation(i):
                 if v1.co != v2.co:
                     different_co_count += 1
             if different_co_count > 0:
-                report += 'vertex position is different on %i vertices \n\n' % (different_co_count)
+                report += 'Vertex Position Is Different on %i Vertices \n\n' % (different_co_count)
                 test_ok = False
         if test_ok:
-            report += 'test ok\n\n'
+            report += 'Test Ok\n\n'
         else:
-            report += 'test result is different\n \n '
+            report += 'Test Result Is Different\n \n '
     print(report)
     return report
 

--- a/scripts/addons/cam/ui.py
+++ b/scripts/addons/cam/ui.py
@@ -98,7 +98,7 @@ class CustomPanel(Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
     bl_context = "objectmode"
-    bl_label = "Import Gcode"
+    bl_label = "Import G-code"
     bl_idname = "OBJECT_PT_importgcode"
 
     bl_options = {'DEFAULT_CLOSED'}
@@ -119,7 +119,7 @@ class CustomPanel(Panel):
         col = layout.column(align=True)
         col = col.row(align=True)
         col.split()
-        col.label(text="Segment length")
+        col.label(text="Segment Length")
 
         col.prop(isettings, "max_segment_size")
         col.enabled = isettings.subdivide
@@ -131,9 +131,9 @@ class CustomPanel(Panel):
 
 
 class WM_OT_gcode_import(Operator, ImportHelper):
-    """Import Gcode, travel lines don't get drawn"""
+    """Import G-code, Travel Lines Don't Get Drawn"""
     bl_idname = "wm.gcode_import"  # important since its how bpy.ops.import_test.some_data is constructed
-    bl_label = "Import Gcode"
+    bl_label = "Import G-code"
 
     # ImportHelper mixin class uses this
     filename_ext = ".txt"
@@ -162,7 +162,7 @@ class import_settings(PropertyGroup):
         default=False,
     )
     output: EnumProperty(
-        name="output type",
+        name="Output Type",
         items=(
             ("mesh", "Mesh", "Make a mesh output"),
             ("curve", "Curve", "Make curve output"),
@@ -171,7 +171,7 @@ class import_settings(PropertyGroup):
     )
     max_segment_size: FloatProperty(
         name="",
-        description="Only Segments bigger then this value get subdivided",
+        description="Only Segments bigger than this value get subdivided",
         default=0.001,
         min=0.0001,
         max=1.0,

--- a/scripts/addons/cam/ui_panels/area.py
+++ b/scripts/addons/cam/ui_panels/area.py
@@ -6,8 +6,8 @@ from ..simple import strInUnits
 
 
 class CAM_AREA_Panel(CAMButtonsPanel, Panel):
-    """CAM operation area panel"""
-    bl_label = "CAM operation area "
+    """CAM Operation Area Panel"""
+    bl_label = "CAM Operation Area"
     bl_idname = "WORLD_PT_CAM_OPERATION_AREA"
     panel_interface_level = 0
 
@@ -45,7 +45,7 @@ class CAM_AREA_Panel(CAMButtonsPanel, Panel):
         self.layout.prop(self.op.movement, 'free_height')
         if self.op.maxz > self.op.movement.free_height:
             self.layout.label(text='!ERROR! COLLISION!')
-            self.layout.label(text='Depth start > Free movement height')
+            self.layout.label(text='Depth Start > Free Movement Height')
             self.layout.label(text='!ERROR! COLLISION!')
 
     def draw_minz(self):
@@ -53,10 +53,10 @@ class CAM_AREA_Panel(CAMButtonsPanel, Panel):
             return
         if self.op.geometry_source in ['OBJECT', 'COLLECTION']:
             if self.op.strategy == 'CURVE':
-                self.layout.label(text="cannot use depth from object using CURVES")
+                self.layout.label(text="Cannot Use Depth from Object Using Curves")
 
             row = self.layout.row(align=True)
-            row.label(text='Set max depth from')
+            row.label(text='Set Max Depth from')
             row.prop(self.op, 'minz_from', text='')
             if self.op.minz_from == 'CUSTOM':
                 self.layout.prop(self.op, 'minz')
@@ -68,16 +68,16 @@ class CAM_AREA_Panel(CAMButtonsPanel, Panel):
                 i = bpy.data.images[self.op.source_image_name]
                 if i is not None:
                     sy = int((self.op.source_image_size_x / i.size[0]) * i.size[1] * 1000000) / 1000
-                    self.layout.label(text='image size on y axis: ' + strInUnits(sy, 8))
+                    self.layout.label(text='Image Size on Y Axis: ' + strInUnits(sy, 8))
                     self.layout.separator()
             self.layout.prop(self.op, 'source_image_offset')
             col = self.layout.column(align=True)
-            col.prop(self.op, 'source_image_crop', text='Crop source image')
+            col.prop(self.op, 'source_image_crop', text='Crop Source Image')
             if self.op.source_image_crop:
-                col.prop(self.op, 'source_image_crop_start_x', text='start x')
-                col.prop(self.op, 'source_image_crop_start_y', text='start y')
-                col.prop(self.op, 'source_image_crop_end_x', text='end x')
-                col.prop(self.op, 'source_image_crop_end_y', text='end y')
+                col.prop(self.op, 'source_image_crop_start_x', text='Start X')
+                col.prop(self.op, 'source_image_crop_start_y', text='Start Y')
+                col.prop(self.op, 'source_image_crop_end_x', text='End X')
+                col.prop(self.op, 'source_image_crop_end_y', text='End Y')
 
     def draw_ambient(self):
         if not self.has_correct_level():

--- a/scripts/addons/cam/ui_panels/chains.py
+++ b/scripts/addons/cam/ui_panels/chains.py
@@ -34,8 +34,8 @@ class CAM_UL_chains(UIList):
 
 
 class CAM_CHAINS_Panel(CAMButtonsPanel, Panel):
-    """CAM chains panel"""
-    bl_label = "CAM chains"
+    """CAM Chains Panel"""
+    bl_label = "CAM Chains"
     bl_idname = "WORLD_PT_CAM_CHAINS"
     panel_interface_level = 1
     always_show_panel = True
@@ -67,16 +67,16 @@ class CAM_CHAINS_Panel(CAMButtonsPanel, Panel):
 
                 if not chain.computing:
                     layout.operator("object.calculate_cam_paths_chain",
-                                    text="Calculate chain paths & Export Gcode")
-                    layout.operator("object.cam_export_paths_chain", text="Export chain gcode")
-                    layout.operator("object.cam_simulate_chain", text="Simulate this chain")
+                                    text="Calculate Chain Paths & Export Gcode")
+                    layout.operator("object.cam_export_paths_chain", text="Export Chain G-code")
+                    layout.operator("object.cam_simulate_chain", text="Simulate This Chain")
 
                     valid, reason = isChainValid(chain, context)
                     if not valid:
-                        layout.label(icon="ERROR", text=f"Can't compute chain - reason:\n")
+                        layout.label(icon="ERROR", text=f"Can't Compute Chain - Reason:\n")
                         layout.label(text=reason)
                 else:
-                    layout.label(text='chain is currently computing')
+                    layout.label(text='Chain Is Currently Computing')
 
                 layout.prop(chain, 'name')
                 layout.prop(chain, 'filename')

--- a/scripts/addons/cam/ui_panels/cutter.py
+++ b/scripts/addons/cam/ui_panels/cutter.py
@@ -5,7 +5,7 @@ from .buttons_panel import CAMButtonsPanel
 
 
 class CAM_CUTTER_Panel(CAMButtonsPanel, Panel):
-    """CAM cutter panel"""
+    """CAM Cutter Panel"""
     bl_label = "CAM Cutter"
     bl_idname = "WORLD_PT_CAM_CUTTER"
     panel_interface_level = 0
@@ -95,9 +95,9 @@ class CAM_CUTTER_Panel(CAMButtonsPanel, Panel):
         if self.op.cutter_type in ['CUSTOM']:
             if self.op.optimisation.use_exact:
                 self.layout.label(
-                    text='Warning - only convex shapes are supported. ', icon='COLOR_RED')
-                self.layout.label(text='If your custom cutter is concave,')
-                self.layout.label(text='switch exact mode off.')
+                    text='Warning - only Convex Shapes Are Supported. ', icon='COLOR_RED')
+                self.layout.label(text='If Your Custom Cutter Is Concave,')
+                self.layout.label(text='Switch Exact Mode Off.')
             self.layout.prop_search(self.op, "cutter_object_name", bpy.data, "objects")
 
     def draw_cutter_diameter(self):
@@ -129,7 +129,7 @@ class CAM_CUTTER_Panel(CAMButtonsPanel, Panel):
         else:
             engagement = round(100 * self.op.dist_between_paths / self.op.cutter_diameter, 1)
 
-        self.layout.label(text=f"Cutter engagement: {engagement}%")
+        self.layout.label(text=f"Cutter Engagement: {engagement}%")
 
         if engagement > 50:
             self.layout.label(text="WARNING: CUTTER ENGAGEMENT > 50%")

--- a/scripts/addons/cam/ui_panels/feedrate.py
+++ b/scripts/addons/cam/ui_panels/feedrate.py
@@ -5,8 +5,8 @@ from .buttons_panel import CAMButtonsPanel
 
 
 class CAM_FEEDRATE_Panel(CAMButtonsPanel, Panel):
-    """CAM feedrate panel"""
-    bl_label = "CAM feedrate"
+    """CAM Feedrate Panel"""
+    bl_label = "CAM Feedrate"
     bl_idname = "WORLD_PT_CAM_FEEDRATE"
     panel_interface_level = 0
 

--- a/scripts/addons/cam/ui_panels/gcode.py
+++ b/scripts/addons/cam/ui_panels/gcode.py
@@ -5,8 +5,8 @@ from .buttons_panel import CAMButtonsPanel
 
 
 class CAM_GCODE_Panel(CAMButtonsPanel, Panel):
-    """CAM operation g-code options panel"""
-    bl_label = "CAM g-code options "
+    """CAM Operation G-code Options Panel"""
+    bl_label = "CAM G-code Options"
     bl_idname = "WORLD_PT_CAM_GCODE"
     panel_interface_level = 1
 

--- a/scripts/addons/cam/ui_panels/info.py
+++ b/scripts/addons/cam/ui_panels/info.py
@@ -28,20 +28,23 @@ from ..simple import strInUnits
 class CAM_INFO_Properties(PropertyGroup):
 
     warnings: StringProperty(
-        name='warnings',
-        description='warnings',
+        name='Warnings',
+        description='Warnings',
         default='',
         update=update_operation,
     )
 
     chipload: FloatProperty(
-        name="chipload", description="Calculated chipload",
+        name="Chipload",
+        description="Calculated chipload",
         default=0.0, unit='LENGTH',
         precision=CHIPLOAD_PRECISION,
     )
 
     duration: FloatProperty(
-        name="Estimated time", default=0.01, min=0.0000,
+        name="Estimated Time",
+        default=0.01,
+        min=0.0000,
         max=MAX_OPERATION_TIME,
         precision=PRECISION,
         unit="TIME",
@@ -49,7 +52,7 @@ class CAM_INFO_Properties(PropertyGroup):
 
 
 class CAM_INFO_Panel(CAMButtonsPanel, Panel):
-    bl_label = "CAM info & warnings"
+    bl_label = "CAM Info & Warnings"
     bl_idname = "WORLD_PT_CAM_INFO"
     panel_interface_level = 0
     always_show_panel = True
@@ -68,9 +71,9 @@ class CAM_INFO_Panel(CAMButtonsPanel, Panel):
         if not self.has_correct_level():
             return
         self.layout.label(
-            text=f'Blendercam version: {".".join([str(x) for x in cam_version])}')
+            text=f'BlenderCAM v{".".join([str(x) for x in cam_version])}')
         if len(bpy.context.preferences.addons['cam'].preferences.new_version_available) > 0:
-            self.layout.label(text=f"New version available:")
+            self.layout.label(text=f"New Version Available:")
             self.layout.label(
                 text=f"  {bpy.context.preferences.addons['cam'].preferences.new_version_available}")
             self.layout.operator("render.cam_update_now")
@@ -81,10 +84,10 @@ class CAM_INFO_Panel(CAMButtonsPanel, Panel):
             return
         ocl_version = opencamlib_version()
         if ocl_version is None:
-            self.layout.label(text="Opencamlib is not installed")
+            self.layout.label(text="OpenCAMLib is not Installed")
         else:
             self.layout.label(
-                text=f"Opencamlib v{ocl_version} installed")
+                text=f"OpenCAMLib v{ocl_version}")
 
     # Display warnings related to the current operation
     def draw_op_warnings(self):
@@ -101,7 +104,7 @@ class CAM_INFO_Panel(CAMButtonsPanel, Panel):
         if not int(self.op.info.duration * 60) > 0:
             return
 
-        time_estimate = f"Operation duration: {int(self.op.info.duration*60)}s "
+        time_estimate = f"Operation Duration: {int(self.op.info.duration*60)}s "
         if self.op.info.duration > 60:
             time_estimate += f" ({int(self.op.info.duration / 60)}h"
             time_estimate += f" {round(self.op.info.duration % 60)}min)"
@@ -136,7 +139,7 @@ class CAM_INFO_Panel(CAMButtonsPanel, Panel):
 
         cost_per_second = bpy.context.scene.cam_machine.hourly_rate / 3600
         total_cost = self.op.info.duration * 60 * cost_per_second
-        op_cost = f"Operation cost: ${total_cost:.2f} (${cost_per_second:.2f}/s)"
+        op_cost = f"Operation Cost: ${total_cost:.2f} (${cost_per_second:.2f}/s)"
         self.layout.label(text=op_cost)
 
     # Display the Info Panel

--- a/scripts/addons/cam/ui_panels/machine.py
+++ b/scripts/addons/cam/ui_panels/machine.py
@@ -5,7 +5,7 @@ from .buttons_panel import CAMButtonsPanel
 
 
 class CAM_MACHINE_Panel(CAMButtonsPanel, Panel):
-    """CAM machine panel"""
+    """CAM Machine Panel"""
     bl_label = "CAM Machine"
     bl_idname = "WORLD_PT_CAM_MACHINE"
     always_show_panel = True

--- a/scripts/addons/cam/ui_panels/material.py
+++ b/scripts/addons/cam/ui_panels/material.py
@@ -22,14 +22,14 @@ from ..constants import PRECISION
 class CAM_MATERIAL_Properties(PropertyGroup):
 
     estimate_from_model: BoolProperty(
-        name="Estimate cut area from model",
+        name="Estimate Cut Area from Model",
         description="Estimate cut area based on model geometry",
         default=True,
         update=update_material,
     )
 
     radius_around_model: FloatProperty(
-        name='Radius around model',
+        name='Radius Around Model',
         description="Increase cut area around the model on X and "
         "Y by this amount",
         default=0.0,
@@ -39,21 +39,21 @@ class CAM_MATERIAL_Properties(PropertyGroup):
     )
 
     center_x: BoolProperty(
-        name="Center on X axis",
+        name="Center on X Axis",
         description="Position model centered on X",
         default=False,
         update=update_material,
     )
 
     center_y: BoolProperty(
-        name="Center on Y axis",
+        name="Center on Y Axis",
         description="Position model centered on Y",
         default=False,
         update=update_material,
     )
 
     z_position: EnumProperty(
-        name="Z placement",
+        name="Z Placement",
         items=(
             ('ABOVE', 'Above', 'Place object vertically above the XY plane'),
             ('BELOW', 'Below', 'Place object vertically below the XY plane'),
@@ -67,7 +67,7 @@ class CAM_MATERIAL_Properties(PropertyGroup):
 
     # material_origin
     origin: FloatVectorProperty(
-        name='Material origin',
+        name='Material Origin',
         default=(0, 0, 0),
         unit='LENGTH',
         precision=PRECISION,
@@ -77,7 +77,7 @@ class CAM_MATERIAL_Properties(PropertyGroup):
 
     # material_size
     size: FloatVectorProperty(
-        name='Material size',
+        name='Material Size',
         default=(0.200, 0.200, 0.100),
         min=0,
         unit='LENGTH',
@@ -92,7 +92,7 @@ class CAM_MATERIAL_Properties(PropertyGroup):
 class CAM_MATERIAL_PositionObject(Operator):
 
     bl_idname = "object.material_cam_position"
-    bl_label = "position object for CAM operation"
+    bl_label = "Position Object for CAM Operation"
     bl_options = {'REGISTER', 'UNDO'}
     interface_level = 0
 
@@ -102,7 +102,7 @@ class CAM_MATERIAL_PositionObject(Operator):
         if operation.object_name in bpy.data.objects:
             positionObject(operation)
         else:
-            print('no object assigned')
+            print('No Object Assigned')
         return {'FINISHED'}
 
     def draw(self, context):
@@ -113,7 +113,7 @@ class CAM_MATERIAL_PositionObject(Operator):
 
 
 class CAM_MATERIAL_Panel(CAMButtonsPanel, Panel):
-    bl_label = "CAM Material size and position"
+    bl_label = "CAM Material Size and Position"
     bl_idname = "WORLD_PT_CAM_MATERIAL"
     panel_interface_level = 0
 
@@ -127,7 +127,7 @@ class CAM_MATERIAL_Panel(CAMButtonsPanel, Panel):
         if not self.has_correct_level():
             return
         if self.op.geometry_source not in ['OBJECT', 'COLLECTION']:
-            self.layout.label(text='Estimated from image')
+            self.layout.label(text='Estimated from Image')
 
     def draw_estimate_from_object(self):
         if not self.has_correct_level():
@@ -136,7 +136,7 @@ class CAM_MATERIAL_Panel(CAMButtonsPanel, Panel):
             self.layout.prop(self.op.material, 'estimate_from_model')
             if self.op.material.estimate_from_model:
                 row_radius = self.layout.row()
-                row_radius.label(text="Additional radius")
+                row_radius.label(text="Additional Radius")
                 row_radius.prop(self.op.material,
                                 'radius_around_model', text='')
             else:
@@ -153,7 +153,7 @@ class CAM_MATERIAL_Panel(CAMButtonsPanel, Panel):
             row_axis.prop(self.op.material, 'center_y')
             self.layout.prop(self.op.material, 'z_position')
             self.layout.operator(
-                "object.material_cam_position", text="Position object")
+                "object.material_cam_position", text="Position Object")
 
     def draw(self, context):
         self.context = context

--- a/scripts/addons/cam/ui_panels/movement.py
+++ b/scripts/addons/cam/ui_panels/movement.py
@@ -22,14 +22,14 @@ from ..constants import (
 class CAM_MOVEMENT_Properties(PropertyGroup):
     # movement parallel_step_back
     type: EnumProperty(
-        name='Movement type',
+        name='Movement Type',
         items=(
             ('CONVENTIONAL', 'Conventional / Up milling',
-             'cutter rotates against the direction of the feed'),
+             'Cutter rotates against the direction of the feed'),
             ('CLIMB', 'Climb / Down milling',
-             'cutter rotates with the direction of the feed'),
+             'Cutter rotates with the direction of the feed'),
             ('MEANDER', 'Meander / Zig Zag',
-             'cutting is done both with and against the '
+             'Cutting is done both with and against the '
              'rotation of the spindle')
         ),
         description='movement type',
@@ -43,16 +43,16 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
             ('INSIDEOUT', 'Inside out', 'a'),
             ('OUTSIDEIN', 'Outside in', 'a')
         ),
-        description='approach to the piece',
+        description='Approach to the piece',
         default='INSIDEOUT',
         update=update_operation,
     )
 
     spindle_rotation: EnumProperty(
-        name='Spindle rotation',
+        name='Spindle Rotation',
         items=(
-            ('CW', 'Clock wise', 'a'),
-            ('CCW', 'Counter clock wise', 'a')
+            ('CW', 'Clockwise', 'a'),
+            ('CCW', 'Counter clockwise', 'a')
         ),
         description='Spindle rotation direction',
         default='CW',
@@ -60,7 +60,7 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     free_height: FloatProperty(
-        name="Free movement height",
+        name="Free Movement Height",
         default=0.01,
         min=0.0000,
         max=32,
@@ -70,7 +70,7 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     useG64: BoolProperty(
-        name="G64 trajectory",
+        name="G64 Trajectory",
         description='Use only if your machine supports '
         'G64 code. LinuxCNC and Mach3 do',
         default=False,
@@ -88,7 +88,7 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     parallel_step_back: BoolProperty(
-        name="Parallel step back",
+        name="Parallel Step Back",
         description='For roughing and finishing in one pass: mills '
         'material in climb mode, then steps back and goes '
         'between 2 last chunks back',
@@ -97,14 +97,14 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     helix_enter: BoolProperty(
-        name="Helix enter - EXPERIMENTAL",
+        name="Helix Enter - EXPERIMENTAL",
         description="Enter material in helix",
         default=False,
         update=update_operation,
     )
 
     ramp_in_angle: FloatProperty(
-        name="Ramp in angle",
+        name="Ramp-in Angle",
         default=pi / 6,
         min=0,
         max=pi * 0.4999,
@@ -115,7 +115,7 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     helix_diameter: FloatProperty(
-        name='Helix diameter - % of cutter diameter',
+        name='Helix Diameter - % of Cutter Diameter',
         default=90,
         min=10,
         max=100,
@@ -125,7 +125,7 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     ramp: BoolProperty(
-        name="Ramp in - EXPERIMENTAL",
+        name="Ramp-in - EXPERIMENTAL",
         description="Ramps down the whole contour, so the cutline looks "
         "like helix",
         default=False,
@@ -133,14 +133,14 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     ramp_out: BoolProperty(
-        name="Ramp out - EXPERIMENTAL",
+        name="Ramp-out - EXPERIMENTAL",
         description="Ramp out to not leave mark on surface",
         default=False,
         update=update_operation,
     )
 
     ramp_out_angle: FloatProperty(
-        name="Ramp out angle",
+        name="Ramp-out Angle",
         default=pi / 6,
         min=0,
         max=pi * 0.4999,
@@ -151,14 +151,14 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     retract_tangential: BoolProperty(
-        name="Retract tangential - EXPERIMENTAL",
+        name="Retract Tangential - EXPERIMENTAL",
         description="Retract from material in circular motion",
         default=False,
         update=update_operation,
     )
 
     retract_radius: FloatProperty(
-        name='Retract arc radius',
+        name='Retract Arc Radius',
         default=0.001,
         min=0.000001,
         max=100,
@@ -168,7 +168,7 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     retract_height: FloatProperty(
-        name='Retract arc height',
+        name='Retract Arc Height',
         default=0.001,
         min=0.00000,
         max=100,
@@ -178,13 +178,13 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     stay_low: BoolProperty(
-        name="Stay low if possible",
+        name="Stay Low if Possible",
         default=True,
         update=update_operation,
     )
 
     merge_dist: FloatProperty(
-        name="Merge distance - EXPERIMENTAL",
+        name="Merge Distance - EXPERIMENTAL",
         default=0.0,
         min=0.0000,
         max=0.1,
@@ -194,15 +194,15 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
     )
 
     protect_vertical: BoolProperty(
-        name="Protect vertical",
+        name="Protect Vertical",
         description="The path goes only vertically next to steep areas",
         default=True,
         update=update_operation,
     )
 
     protect_vertical_limit: FloatProperty(
-        name="Verticality limit",
-        description="What angle is allready considered vertical",
+        name="Verticality Limit",
+        description="What angle is already considered vertical",
         default=pi / 45,
         min=0,
         max=pi * 0.5,
@@ -214,8 +214,8 @@ class CAM_MOVEMENT_Properties(PropertyGroup):
 
 
 class CAM_MOVEMENT_Panel(CAMButtonsPanel, Panel):
-    """CAM movement panel"""
-    bl_label = "CAM movement"
+    """CAM Movement Panel"""
+    bl_label = "CAM Movement"
     bl_idname = "WORLD_PT_CAM_MOVEMENT"
     panel_interface_level = 0
 
@@ -249,7 +249,7 @@ class CAM_MOVEMENT_Panel(CAMButtonsPanel, Panel):
             return
         self.layout.prop(self.op.movement, 'free_height')
         if self.op.maxz > self.op.movement.free_height:
-            self.layout.label(text='Depth start > Free movement')
+            self.layout.label(text='Depth Start > Free Movement')
             self.layout.label(text='POSSIBLE COLLISION')
 
     def draw_use_g64(self):

--- a/scripts/addons/cam/ui_panels/op_properties.py
+++ b/scripts/addons/cam/ui_panels/op_properties.py
@@ -5,8 +5,8 @@ from .buttons_panel import CAMButtonsPanel
 
 
 class CAM_OPERATION_PROPERTIES_Panel(CAMButtonsPanel, Panel):
-    """CAM operation properties panel"""
-    bl_label = "CAM operation setup"
+    """CAM Operation Properties Panel"""
+    bl_label = "CAM Operation Setup"
     bl_idname = "WORLD_PT_CAM_OPERATION"
     panel_interface_level = 0
 
@@ -44,9 +44,9 @@ class CAM_OPERATION_PROPERTIES_Panel(CAMButtonsPanel, Panel):
             engagement = round(100 * self.op.dist_between_paths / self.op.cutter_diameter, 1)
 
         if engagement > 50:
-            self.layout.label(text="Warning: High cutter engagement")
+            self.layout.label(text="Warning: High Cutter Engagement")
 
-        self.layout.label(text=f"Cutter engagement: {engagement}%")
+        self.layout.label(text=f"Cutter Engagement: {engagement}%")
 
     def draw_machine_axis(self):
         if not self.has_correct_level():
@@ -139,14 +139,14 @@ class CAM_OPERATION_PROPERTIES_Panel(CAMButtonsPanel, Panel):
         if not self.has_correct_level():
             return
         if self.op.strategy in ['WATERLINE']:
-            self.layout.label(text="OCL doesn't support fill areas")
+            self.layout.label(text="Ocl Doesn't Support Fill Areas")
             if not self.op.optimisation.use_opencamlib:
                 self.layout.prop(self.op, 'slice_detail')
                 self.layout.prop(self.op, 'waterline_fill')
                 if self.op.waterline_fill:
                     self.layout.prop(self.op, 'dist_between_paths')
                     self.layout.prop(self.op, 'waterline_project')
-            self.layout.label(text="Waterline needs a skin margin")
+            self.layout.label(text="Waterline Needs a Skin Margin")
 
     def draw_carve_options(self):
         if not self.has_correct_level():
@@ -203,7 +203,7 @@ class CAM_OPERATION_PROPERTIES_Panel(CAMButtonsPanel, Panel):
                 self.layout.prop(self.op, 'bridges_height')
                 self.layout.prop_search(self.op, "bridges_collection_name", bpy.data, "collections")
                 self.layout.prop(self.op, 'use_bridge_modifiers')
-            self.layout.operator("scene.cam_bridges_add", text="Autogenerate bridges")
+            self.layout.operator("scene.cam_bridges_add", text="Autogenerate Bridges / Tabs")
 
     def draw_skin(self):
         if not self.has_correct_level():

--- a/scripts/addons/cam/ui_panels/operations.py
+++ b/scripts/addons/cam/ui_panels/operations.py
@@ -14,8 +14,8 @@ from .buttons_panel import CAMButtonsPanel
 
 
 class CAM_OPERATIONS_Panel(CAMButtonsPanel, Panel):
-    """CAM operations panel"""
-    bl_label = "CAM operations"
+    """CAM Operations Panel"""
+    bl_label = "CAM Operations"
     bl_idname = "WORLD_PT_CAM_OPERATIONS"
     always_show_panel = True
     panel_interface_level = 0
@@ -60,14 +60,14 @@ class CAM_OPERATIONS_Panel(CAMButtonsPanel, Panel):
             return
         if self.op.maxz > self.op.movement.free_height:
             self.layout.label(text='!ERROR! COLLISION!')
-            self.layout.label(text='Depth start > Free movement height')
+            self.layout.label(text='Depth Start > Free Movement Height')
             self.layout.label(text='!ERROR! COLLISION!')
             self.layout.prop(self.op.movement, 'free_height')
 
         if not self.op.valid:
-            self.layout.label(text="Select a valid object to calculate the path.")
+            self.layout.label(text="Select a Valid Object to Calculate the Path.")
         # will be disable if not valid
-        self.layout.operator("object.calculate_cam_path", text="Calculate path & export Gcode")
+        self.layout.operator("object.calculate_cam_path", text="Calculate Path & Export Gcode")
 
     def draw_export_gcode(self):
         if not self.has_correct_level():
@@ -82,7 +82,7 @@ class CAM_OPERATIONS_Panel(CAMButtonsPanel, Panel):
         if not self.has_correct_level():
             return
         if self.op.valid:
-            self.layout.operator("object.cam_simulate", text="Simulate this operation")
+            self.layout.operator("object.cam_simulate", text="Simulate This Operation")
 
     def draw_op_name(self):
         if not self.has_correct_level():

--- a/scripts/addons/cam/ui_panels/optimisation.py
+++ b/scripts/addons/cam/ui_panels/optimisation.py
@@ -23,14 +23,14 @@ from ..constants import PRECISION
 class CAM_OPTIMISATION_Properties(PropertyGroup):
 
     optimize: BoolProperty(
-        name="Reduce path points",
+        name="Reduce Path Points",
         description="Reduce path points",
         default=True,
         update=update_operation,
     )
 
     optimize_threshold: FloatProperty(
-        name="Reduction threshold in μm",
+        name="Reduction Threshold in μm",
         default=.2,
         min=0.000000001,
         max=1000,
@@ -39,7 +39,7 @@ class CAM_OPTIMISATION_Properties(PropertyGroup):
     )
 
     use_exact: BoolProperty(
-        name="Use exact mode",
+        name="Use Exact Mode",
         description="Exact mode allows greater precision, but is slower "
         "with complex meshes",
         default=True,
@@ -47,7 +47,7 @@ class CAM_OPTIMISATION_Properties(PropertyGroup):
     )
 
     imgres_limit: IntProperty(
-        name="Maximum resolution in megapixels",
+        name="Maximum Resolution in Megapixels",
         default=16,
         min=1,
         max=512,
@@ -57,7 +57,7 @@ class CAM_OPTIMISATION_Properties(PropertyGroup):
     )
 
     pixsize: FloatProperty(
-        name="sampling raster detail",
+        name="Sampling Raster Detail",
         default=0.0001,
         min=0.00001,
         max=0.1,
@@ -74,7 +74,7 @@ class CAM_OPTIMISATION_Properties(PropertyGroup):
     )
 
     exact_subdivide_edges: BoolProperty(
-        name="Auto subdivide long edges",
+        name="Auto Subdivide Long Edges",
         description="This can avoid some collision issues when "
         "importing CAD models",
         default=False,
@@ -82,7 +82,7 @@ class CAM_OPTIMISATION_Properties(PropertyGroup):
     )
 
     circle_detail: IntProperty(
-        name="Detail of circles used for curve offsets",
+        name="Detail of Circles Used for Curve Offsets",
         default=64,
         min=12,
         max=512,
@@ -90,7 +90,7 @@ class CAM_OPTIMISATION_Properties(PropertyGroup):
     )
 
     simulation_detail: FloatProperty(
-        name="Simulation sampling raster detail",
+        name="Simulation Sampling Raster Detail",
         default=0.0002,
         min=0.00001,
         max=0.01,
@@ -101,8 +101,8 @@ class CAM_OPTIMISATION_Properties(PropertyGroup):
 
 
 class CAM_OPTIMISATION_Panel(CAMButtonsPanel, Panel):
-    """CAM optimisation panel"""
-    bl_label = "CAM optimisation"
+    """CAM Optimisation Panel"""
+    bl_label = "CAM Optimisation"
     bl_idname = "WORLD_PT_CAM_OPTIMISATION"
     panel_interface_level = 2
 
@@ -150,7 +150,7 @@ class CAM_OPTIMISATION_Panel(CAMButtonsPanel, Panel):
         ocl_version = opencamlib_version()
 
         if ocl_version is None:
-            self.layout.label(text="Opencamlib is not available ")
+            self.layout.label(text="OpenCAMLib is not Available ")
             self.layout.prop(self.op.optimisation, 'exact_subdivide_edges')
         else:
             self.layout.prop(self.op.optimisation, 'use_opencamlib')

--- a/scripts/addons/cam/ui_panels/pack.py
+++ b/scripts/addons/cam/ui_panels/pack.py
@@ -5,8 +5,8 @@ from .buttons_panel import CAMButtonsPanel
 
 
 class CAM_PACK_Panel(CAMButtonsPanel, Panel):
-    """CAM material panel"""
-    bl_label = "Pack curves on sheet"
+    """CAM Pack Panel"""
+    bl_label = "Pack Curves on Sheet"
     bl_idname = "WORLD_PT_CAM_PACK"
     panel_interface_level = 2
 
@@ -16,8 +16,8 @@ class CAM_PACK_Panel(CAMButtonsPanel, Panel):
         layout = self.layout
         scene = bpy.context.scene
         settings = scene.cam_pack
-        layout.label(text='warning - algorithm is slow.')
-        layout.label(text='only for curves now.')
+        layout.label(text='Warning - Algorithm Is Slow.')
+        layout.label(text='Only for Curves Now.')
 
         layout.operator("object.cam_pack_objects")
         layout.prop(settings, 'sheet_fill_direction')

--- a/scripts/addons/cam/ui_panels/slice.py
+++ b/scripts/addons/cam/ui_panels/slice.py
@@ -5,8 +5,8 @@ from .buttons_panel import CAMButtonsPanel
 
 
 class CAM_SLICE_Panel(CAMButtonsPanel, Panel):
-    """CAM slicer panel"""
-    bl_label = "Slice model to plywood sheets"
+    """CAM Slicer Panel"""
+    bl_label = "Slice Model to Plywood Sheets"
     bl_idname = "WORLD_PT_CAM_SLICE"
     panel_interface_level = 2
 

--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -68,7 +68,7 @@ from .opencamlib.opencamlib import (
     oclSample,
     oclResampleChunks,
 )
-from .polygon_utils_cam import shapelyToCurve
+from .polygon_utils_cam import shapelyToCurve, shapelyToMultipolygon
 from .simple import (
     activate,
     progress,
@@ -287,21 +287,21 @@ def getOperationSources(o):
 def getBounds(o):
     # print('kolikrat sem rpijde')
     if o.geometry_source == 'OBJECT' or o.geometry_source == 'COLLECTION' or o.geometry_source == 'CURVE':
-        print("valid geometry")
+        print("Valid Geometry")
         minx, miny, minz, maxx, maxy, maxz = getBoundsWorldspace(o.objects, o.use_modifiers)
 
         if o.minz_from == 'OBJECT':
             if minz == 10000000:
                 minz = 0
-            print("minz from object:" + str(minz))
+            print("Minz from Object:" + str(minz))
             o.min.z = minz
             o.minz = o.min.z
         else:
             o.min.z = o.minz  # max(bb[0][2]+l.z,o.minz)#
-            print("not minz from object")
+            print("Not Minz from Object")
 
         if o.material.estimate_from_model:
-            print("Estimate material from model")
+            print("Estimate Material from Model")
 
             o.min.x = minx - o.material.radius_around_model
             o.min.y = miny - o.material.radius_around_model
@@ -310,7 +310,7 @@ def getBounds(o):
             o.max.x = maxx + o.material.radius_around_model
             o.max.y = maxy + o.material.radius_around_model
         else:
-            print("not material from model")
+            print("Not Material from Model")
             o.min.x = o.material.origin.x
             o.min.y = o.material.origin.y
             o.min.z = o.material.origin.z - o.material.size.z
@@ -342,14 +342,14 @@ def getBounds(o):
     s = bpy.context.scene
     m = s.cam_machine
     # make sure this message only shows once and goes away once fixed
-    o.info.warnings.replace('Operation exceeds your machine limits\n', '')
+    o.info.warnings.replace('Operation Exceeds Your Machine Limits\n', '')
     if o.max.x - o.min.x > m.working_area.x or o.max.y - o.min.y > m.working_area.y \
             or o.max.z - o.min.z > m.working_area.z:
-        o.info.warnings += 'Operation exceeds your machine limits\n'
+        o.info.warnings += 'Operation Exceeds Your Machine Limits\n'
 
 
 def getBoundsMultiple(operations):
-    """gets bounds of multiple operations, mainly for purpose of simulations or rest milling. highly suboptimal."""
+    """Gets Bounds of Multiple Operations, Mainly for Purpose of Simulations or Rest Milling. Highly Suboptimal."""
     maxx = maxy = maxz = -10000000
     minx = miny = minz = 10000000
     for o in operations:
@@ -458,7 +458,7 @@ async def sampleChunks(o, pathSamples, layers):
         ob = bpy.data.objects[o.object_name]
         zinvert = ob.location.z + maxz  # ob.bound_box[6][2]
 
-    print(f"Total sample points {totlen}")
+    print(f"Total Sample Points {totlen}")
 
     n = 0
     last_percent = -1
@@ -616,7 +616,7 @@ async def sampleChunks(o, pathSamples, layers):
         lastrunchunks = thisrunchunks
 
     # print(len(layerchunks[i]))
-    progress('checking relations between paths')
+    progress('Checking Relations Between Paths')
     timingstart(sortingtime)
 
     if o.strategy == 'PARALLEL' or o.strategy == 'CROSS' or o.strategy == 'OUTLINEFILL':
@@ -665,7 +665,7 @@ async def sampleChunksNAxis(o, pathSamples, layers):
     cutterdepth = cutter.dimensions.z / 2
 
     t = time.time()
-    print('sampling paths')
+    print('Sampling Paths')
 
     totlen = 0  # total length of all chunks, to estimate sampling time.
     for chs in pathSamples:
@@ -868,7 +868,7 @@ async def sampleChunksNAxis(o, pathSamples, layers):
 
     # print(len(layerchunks[i]))
 
-    progress('checking relations between paths')
+    progress('Checking Relations Between Paths')
     """#this algorithm should also work for n-axis, but now is "sleeping"
     if (o.strategy=='PARALLEL' or o.strategy=='CROSS'):
         if len(layers)>1:# sorting help so that upper layers go first always
@@ -1025,7 +1025,7 @@ def overlaps(bb1, bb2):  # true if bb1 is child of bb2
 
 
 async def connectChunksLow(chunks, o):
-    """ connects chunks that are close to each other without lifting, sampling them 'low' """
+    """ Connects Chunks that Are Close to Each Other without Lifting, Sampling Them 'low' """
     if not o.movement.stay_low or (o.strategy == 'CARVE' and o.carve_depth > 0):
         return chunks
 
@@ -1183,7 +1183,7 @@ def getVectorRight(lastv, verts):
 
 def cleanUpDict(ndict):
     # now it should delete all junk first, iterate over lonely verts.
-    print('removing lonely points')
+    print('Removing Lonely Points')
     # found_solitaires=True
     # while found_solitaires:
     found_solitaires = False
@@ -1234,8 +1234,8 @@ def cutloops(csource, parentloop, loops):
 
 
 def getOperationSilhouete(operation):
-    """gets silhouete for the operation
-        uses image thresholding for everything except curves.
+    """Gets Silhouette for the Operation
+        Uses Image Thresholding for Everything Except Curves.
     """
     if operation.update_silhouete_tag:
         image = None
@@ -1255,7 +1255,7 @@ def getOperationSilhouete(operation):
                     totfaces += len(ob.data.polygons)
 
         if (stype == 'OBJECTS' and totfaces > 200000) or stype == 'IMAGE':
-            print('image method')
+            print('Image Method')
             samples = renderSampleImage(operation)
             if stype == 'OBJECTS':
                 i = samples > operation.minz - 0.0000001
@@ -1296,7 +1296,7 @@ def getObjectSilhouete(stype, objects=None, use_modifiers=False):
         if totfaces < 20000000:  # boolean polygons method originaly was 20 000 poly limit, now limitless,
             # it might become teribly slow, but who cares?
             t = time.time()
-            print('shapely getting silhouette')
+            print('Shapely Getting Silhouette')
             polys = []
             for ob in objects:
                 if use_modifiers:
@@ -1334,7 +1334,7 @@ def getObjectSilhouete(stype, objects=None, use_modifiers=False):
             if totfaces < 20000:
                 p = sops.unary_union(polys)
             else:
-                print('computing in parts')
+                print('Computing in Parts')
                 bigshapes = []
                 i = 1
                 part = 20000
@@ -1346,13 +1346,13 @@ def getObjectSilhouete(stype, objects=None, use_modifiers=False):
                 if (i - 1) * part < totfaces:
                     last_ar = polys[(i - 1) * part:]
                     bigshapes.append(sops.unary_union(last_ar))
-                print('joining')
+                print('Joining')
                 p = sops.unary_union(bigshapes)
 
             print(time.time() - t)
 
             t = time.time()
-            silhouete = [p]  # [polygon_utils_cam.Shapely2Polygon(p)]
+            silhouete = shapelyToMultipolygon(p)  # [polygon_utils_cam.Shapely2Polygon(p)]
 
     return silhouete
 
@@ -1427,7 +1427,7 @@ def getObjectOutline(radius, o, Offset):  # FIXME: make this one operation indep
 
 
 def addOrientationObject(o):
-    """the orientation object should be used to set up orientations of the object for 4 and 5 axis milling."""
+    """The Orientation Object Should Be Used to Set up Orientations of the Object for 4 and 5 Axis Milling."""
     name = o.name + ' orientation'
     s = bpy.context.scene
     if s.objects.find(name) == -1:
@@ -1588,7 +1588,7 @@ class Point:
 
 
 def unique(L):
-    """Return a list of unhashable elements in s, but without duplicates.
+    """Return a List of Unhashable Elements in S, but without Duplicates.
     [[1, 2], [2, 3], [1, 2]] >>> [[1, 2], [2, 3]]"""
     # For unhashable objects, you can sort the sequence and then scan from the end of the list,
     # deleting duplicates as you go
@@ -1684,9 +1684,9 @@ def cleanupIndexed(operation):
 
 
 def rotTo2axes(e, axescombination):
-    """converts an orientation object rotation to rotation defined by 2 rotational axes on the machine -
-    for indexed machining.
-    attempting to do this for all axes combinations.
+    """Converts an Orientation Object Rotation to Rotation Defined by 2 Rotational Axes on the Machine -
+    for Indexed Machining.
+    Attempting to Do This for All Axes Combinations.
     """
     v = Vector((0, 0, 1))
     v.rotate(e)
@@ -1813,13 +1813,13 @@ _IS_LOADING_DEFAULTS = False
 
 
 def updateMachine(self, context):
-    print('update machine ')
+    print('Update Machine')
     if not _IS_LOADING_DEFAULTS:
         addMachineAreaObject()
 
 
 def updateMaterial(self, context):
-    print('update material')
+    print('Update Material')
     addMaterialAreaObject()
 
 
@@ -1885,7 +1885,7 @@ def operationValid(self, context):
     o = scene.cam_operations[scene.cam_active_operation]
     o.changed = True
     o.valid = isValid(o, context)
-    invalidmsg = "Invalid source object for operation.\n"
+    invalidmsg = "Invalid Source Object for Operation.\n"
     if o.valid:
         o.info.warnings = ""
     else:
@@ -1908,9 +1908,9 @@ def isChainValid(chain, context):
             if so.name == cho.name:
                 found_op = so
         if found_op == None:
-            return (False, f"Couldn't find operation {cho.name}")
+            return (False, f"Couldn't Find Operation {cho.name}")
         if isValid(found_op, context) is False:
-            return (False, f"Operation {found_op.name} is not valid")
+            return (False, f"Operation {found_op.name} Is Not Valid")
     return (True, "")
 
 
@@ -1920,8 +1920,8 @@ def updateOperationValid(self, context):
 
 # Update functions start here
 def updateChipload(self, context):
-    """this is very simple computation of chip size, could be very much improved"""
-    print('update chipload ')
+    """This Is Very Simple Computation of Chip Size, Could Be Very Much Improved"""
+    print('Update Chipload ')
     o = self
     # Old chipload
     o.info.chipload = (o.feedrate / (o.spindle_rpm * o.cutter_flutes))
@@ -1942,15 +1942,15 @@ def updateChipload(self, context):
 
 
 def updateOffsetImage(self, context):
-    """refresh offset image tag for rerendering"""
+    """Refresh Offset Image Tag for Rerendering"""
     updateChipload(self, context)
-    print('update offset')
+    print('Update Offset')
     self.changed = True
     self.update_offsetimage_tag = True
 
 
 def updateZbufferImage(self, context):
-    """changes tags so offset and zbuffer images get updated on calculation time."""
+    """Changes Tags so Offset and Zbuffer Images Get Updated on Calculation Time."""
     # print('updatezbuf')
     # print(self,context)
     self.changed = True
@@ -1962,7 +1962,7 @@ def updateZbufferImage(self, context):
 def updateStrategy(o, context):
     """"""
     o.changed = True
-    print('update strategy')
+    print('Update Strategy')
     if o.machine_axes == '5' or (
             o.machine_axes == '4' and o.strategy4axis == 'INDEXED'):  # INDEXED 4 AXIS DOESN'T EXIST NOW...
         addOrientationObject(o)
@@ -1976,35 +1976,35 @@ def updateCutout(o, context):
 
 
 def updateExact(o, context):
-    print('update exact ')
+    print('Update Exact ')
     o.changed = True
     o.update_zbufferimage_tag = True
     o.update_offsetimage_tag = True
     if o.optimisation.use_exact:
         if o.strategy == 'POCKET' or o.strategy == 'MEDIAL_AXIS' or o.inverse:
             o.optimisation.use_opencamlib = False
-            print('Current operation cannot use exact mode')
+            print('Current Operation Cannot Use Exact Mode')
     else:
         o.optimisation.use_opencamlib = False
 
 
 def updateOpencamlib(o, context):
-    print('update opencamlib ')
+    print('Update OpenCAMLib ')
     o.changed = True
     if o.optimisation.use_opencamlib and (
             o.strategy == 'POCKET' or o.strategy == 'MEDIAL_AXIS'):
         o.optimisation.use_exact = False
         o.optimisation.use_opencamlib = False
-        print('Current operation cannot use opencamlib')
+        print('Current Operation Cannot Use OpenCAMLib')
 
 
 def updateBridges(o, context):
-    print('update bridges ')
+    print('Update Bridges ')
     o.changed = True
 
 
 def updateRotation(o, context):
-    print('update rotation')
+    print('Update Rotation')
     if o.enable_B or o.enable_A:
         print(o, o.rotation_A)
         ob = bpy.data.objects[o.object_name]
@@ -2029,7 +2029,7 @@ def updateRotation(o, context):
 #    o.changed = True
 
 def updateRest(o, context):
-    print('update rest ')
+    print('Update Rest ')
     o.changed = True
 
 
@@ -2101,7 +2101,7 @@ def update_zbuffer_image(self, context):
 
 @bpy.app.handlers.persistent
 def check_operations_on_load(context):
-    """checks any broken computations on load and reset them."""
+    """Checks Any Broken Computations on Load and Reset Them."""
     s = bpy.context.scene
     for o in s.cam_operations:
         if o.computing:
@@ -2113,7 +2113,7 @@ def check_operations_on_load(context):
         machine_preset = bpy.context.preferences.addons[
             "cam"].preferences.machine_preset = bpy.context.preferences.addons["cam"].preferences.default_machine_preset
         if len(machine_preset) > 0:
-            print("Loading preset:", machine_preset)
+            print("Loading Preset:", machine_preset)
             # load last used machine preset
             bpy.ops.script.execute_preset(
                 filepath=machine_preset, menu_idname="CAM_MACHINE_MT_presets"

--- a/scripts/addons/cam/voronoi.py
+++ b/scripts/addons/cam/voronoi.py
@@ -581,16 +581,16 @@ class Halfedge(object):
 
     def dump(self):
         print("Halfedge--------------------------")
-        print("left: ", self.left)
-        print("right: ", self.right)
-        print("edge: ", self.edge)
-        print("pm: ", self.pm)
-        print("vertex: "),
+        print("Left: ", self.left)
+        print("Right: ", self.right)
+        print("Edge: ", self.edge)
+        print("PM: ", self.pm)
+        print("Vertex: "),
         if self.vertex:
             self.vertex.dump()
         else:
             print("None")
-        print("ystar: ", self.ystar)
+        print("Ystar: ", self.ystar)
 
     def __lt__(self, other):
         if self.ystar < other.ystar:


### PR DESCRIPTION
## Title Case & Naming
Enforced title case and naming consistency across all names, labels, print and progress strings. Fixed typos and duplicate entries.
Enforced consistent styling: 'BlenderCAM', 'OpenCAMLib' throughout
Renamed the engine - from 'cam' to 'BlenderCAM'

## Bridges Fix
Bridges would only generate for Curve based objects.
If an object was Mesh based it would fail with a 'list has no attribute geoms' error message.
Resolved by taking the polygon generated by the getObjectSilhouette function and converting it to a shapely multipolygon, which has the geoms property.

> [!NOTE]
> Bridges functionality appears to still be broken. Path generation did not take any bridges or bridge collections into account.
> The only way I got it to recognize bridges was by converting them to meshes and joining them with the object.
> This will need to be addressed in a future patch.

## README Update
- fixed an inconsistency in the pipes in the Files Organization Diagram.
- edited the 'documents' comment to reflect the naming used elsewhere - 'How to Use (Wiki)'