### PR TITLE
License update, format header comment

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,281 +1,622 @@
-GNU GENERAL PUBLIC LICENSE
-                       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
                             Preamble
 
-  The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-License is intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users.  This
-General Public License applies to most of the Free Software
-Foundation's software and to any other program whose authors commit to
-using it.  (Some other Free Software Foundation software is covered by
-the GNU Lesser General Public License instead.)  You can apply it to
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it
-in new free programs; and that you know you can do these things.
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-  To protect your rights, we need to make restrictions that forbid
-anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if you
-distribute copies of the software, or if you modify it.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
   For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must give the recipients all the rights that
-you have.  You must make sure that they, too, receive or can get the
-source code.  And you must show them these terms so they know their
-rights.
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-  We protect your rights with two steps: (1) copyright the software, and
-(2) offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-  Also, for each author's protection and ours, we want to make certain
-that everyone understands that there is no warranty for this free
-software.  If the software is modified by someone else and passed on, we
-want its recipients to know that what they have is not the original, so
-that any problems introduced by others will not reflect on the original
-authors' reputations.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-  Finally, any free program is threatened constantly by software
-patents.  We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary.  To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-                    GNU GENERAL PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+                       TERMS AND CONDITIONS
 
-  0. This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License.  The "Program", below,
-refers to any such program or work, and a "work based on the Program"
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language.  (Hereinafter, translation is included without limitation in
-the term "modification".)  Each licensee is addressed as "you".
+  0. Definitions.
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
-running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the
-Program (independent of having been made by running the Program).
-Whether that is true depends on what the Program does.
+  "This License" refers to version 3 of the GNU General Public License.
 
-  1. You may copy and distribute verbatim copies of the Program's
-source code as you receive it, in any medium, provided that you
-conspicuously and appropriately publish on each copy an appropriate
-copyright notice and disclaimer of warranty; keep intact all the
-notices that refer to this License and to the absence of any warranty;
-and give any other recipients of the Program a copy of this License
-along with the Program.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-  2. You may modify your copy or copies of the Program or any portion
-of it, thus forming a work based on the Program, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-    a) You must cause the modified files to carry prominent notices
-    stating that you changed the files and the date of any change.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-    b) You must cause any work that you distribute or publish, that in
-    whole or in part contains or is derived from the Program or any
-    part thereof, to be licensed as a whole at no charge to all third
-    parties under the terms of this License.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-    c) If the modified program normally reads commands interactively
-    when run, you must cause it, when started running for such
-    interactive use in the most ordinary way, to print or display an
-    announcement including an appropriate copyright notice and a
-    notice that there is no warranty (or else, saying that you provide
-    a warranty) and that users may redistribute the program under
-    these conditions, and telling the user how to view a copy of this
-    License.  (Exception: if the Program itself is interactive but
-    does not normally print such an announcement, your work based on
-    the Program is not required to print an announcement.)
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-These requirements apply to the modified work as a whole.  If
-identifiable sections of that work are not derived from the Program,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
-distribute the same sections as part of a whole which is a work based
-on the Program, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote it.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Program.
+  1. Source Code.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-  3. You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-    a) Accompany it with the complete corresponding machine-readable
-    source code, which must be distributed under the terms of Sections
-    1 and 2 above on a medium customarily used for software interchange; or,
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-    b) Accompany it with a written offer, valid for at least three
-    years, to give any third party, for a charge no more than your
-    cost of physically performing source distribution, a complete
-    machine-readable copy of the corresponding source code, to be
-    distributed under the terms of Sections 1 and 2 above on a medium
-    customarily used for software interchange; or,
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-    c) Accompany it with the information you received as to the offer
-    to distribute corresponding source code.  (This alternative is
-    allowed only for noncommercial distribution and only if you
-    received the program in object code or executable form with such
-    an offer, in accord with Subsection b above.)
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-The source code for a work means the preferred form of the work for
-making modifications to it.  For an executable work, complete source
-code means all the source code for all modules it contains, plus any
-associated interface definition files, plus the scripts used to
-control compilation and installation of the executable.  However, as a
-special exception, the source code distributed need not include
-anything that is normally distributed (in either source or binary
-form) with the major components (compiler, kernel, and so on) of the
-operating system on which the executable runs, unless that component
-itself accompanies the executable.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-If distribution of executable or object code is made by offering
-access to copy from a designated place, then offering equivalent
-access to copy the source code from the same place counts as
-distribution of the source code, even though third parties are not
-compelled to copy the source along with the object code.
+  2. Basic Permissions.
 
-  4. You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License.  Any attempt
-otherwise to copy, modify, sublicense or distribute the Program is
-void, and will automatically terminate your rights under this License.
-However, parties who have received copies, or rights, from you under
-this License will not have their licenses terminated so long as such
-parties remain in full compliance.
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-  5. You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Program or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
-modifying or distributing the Program (or any work based on the
-Program), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Program or works based on it.
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-  6. Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions.  You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties to
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
 this License.
 
-  7. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Program at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Program by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Program.
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply and the section as a whole is intended to apply in other
-circumstances.
+  13. Use with the GNU Affero General Public License.
 
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system, which is
-implemented by public license practices.  Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
 
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
+  14. Revised Versions of this License.
 
-  8. If the distribution and/or use of the Program is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Program under this License
-may add an explicit geographical distribution limitation excluding
-those countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
-
-  9. The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time.  Such new versions will
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
-Each version is given a distinguishing version number.  If the Program
-specifies a version number of this License which applies to it and "any
-later version", you have the option of following the terms and conditions
-either of that version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number of
-this License, you may choose any version ever published by the Free Software
-Foundation.
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
 
-  10. If you wish to incorporate parts of the Program into other free
-programs whose distribution conditions are different, write to the author
-to ask for permission.  For software which is copyrighted by the Free
-Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this.  Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software and
-of promoting the sharing and reuse of software generally.
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
 
-                            NO WARRANTY
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
 
-  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
+  15. Disclaimer of Warranty.
 
-  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
 
                      END OF TERMS AND CONDITIONS
 
@@ -287,15 +628,15 @@ free software which everyone can redistribute and change under these terms.
 
   To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
+state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {description}
-    Copyright (C) {year}  {fullname}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-    This program is free software; you can redistribute it and/or modify
+    This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
@@ -303,38 +644,31 @@ the "copyright" line and a pointer to where the full notice is found.
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
 
 The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w' and `show c'; they could even be
-mouse-clicks or menu items--whatever suits your program.
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
 
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
 
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-
-  {signature of Ty Coon}, 1 April 1989
-  Ty Coon, President of Vice
-
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.
-
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 - - -
 
-### • [About](#About) • [How to Use](#-how-to-use-wiki) • [Features](#-features) • [Post-Processors](#-post-processors) • [Files](#-files-organisation) • [Contribute](#-contribute) • [License](#-license) • [Disclaimer](#-disclaimer) •
+### [About](#About) • [How to Use](#-how-to-use-wiki) • [Features](#-features) • [Post-Processors](#-post-processors) • [Files](#-files-organisation) • [Contribute](#-contribute) • [License](#-license) • [Disclaimer](#-disclaimer)
 
 - - - 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 - - -
 
-### • [About](#About) • [How to Use](#-how-to-use-wiki) • [Features](#-features) • [Post-Processors](#-post-processors) • [Files](#-files-organisation) • [Contributing](#-contributing) • [License](#-license) • [Disclaimer](#-disclaimer) •
+### • [About](#About) • [How to Use](#-how-to-use-wiki) • [Features](#-features) • [Post-Processors](#-post-processors) • [Files](#-files-organisation) • [Contribute](#-contribute) • [License](#-license) • [Disclaimer](#-disclaimer) •
 
 - - - 
 
@@ -119,7 +119,7 @@ BlenderCAM works on Windows or Linux.
 
 
 
-## 🤝 Contributing
+## 🤝 Contribute
 #### BlenderCAM is in active development.
 
 Originally created by [Vilem Novak](https://github.com/vilemduha), the addon is currently maintained by [Alain Pelletier](https://github.com/pppalain) and a team of contributors. 
@@ -143,9 +143,9 @@ Hirutso Enni, Kurt Jensen, Dan Falck, Dan Heeks, Brad Collette, Michael Haberler
 BlenderCAM is licensed under GPLv3, __UNLESS OTHERWISE INDICATED__.
 
 > [!NOTE]
-> Some files in this addon use code from other sources, see the file docstring a the top of each file for attribution and license information.
+> _Some files in this addon use code from other sources, see the file docstring a the top of each file for attribution and license information._
 > 
-> Please ensure that you read and abide by the license terms given for each file.
+> _Please ensure that you read and abide by the license terms given for each file._
 
 ## 🤕 DISCLAIMER
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ BlenderCAM works on Windows or Linux.
 
 Originally created by [Vilem Novak](https://github.com/vilemduha), the addon is currently maintained by [Alain Pelletier](https://github.com/pppalain) and a team of contributors. 
 
-If you wish to contribute to the addon, your code must be GPL or a more permissive license (e.g.: MIT, Public Domain).
-
 If you are a developer who would like to contribute to the project, please fork and open pull requests.
+
+If you wish to contribute to the addon, your code must be GPL or a more permissive license (e.g.: MIT, Public Domain).
 
 > [!TIP]
 > _If you need help or want to discuss about BlenderCAM you can join the [Chat Room #BlenderCAM:matrix.org on Matrix](https://riot.im/app/#/room/#blendercam:matrix.org)._

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <br>
 
 
-[About](#About) • [How to Use](#-how-to-use-wiki) • [Features](#-features) • [Post-Processors](#-post-processors) • [Files](#-files-organisation) • [Contributing](#-contributing) • [License](#-disclaimer)
+[About](#About) • [How to Use](#-how-to-use-wiki) • [Features](#-features) • [Post-Processors](#-post-processors) • [Files](#-files-organisation) • [Contributing](#-contributing) • [License](#-license) • [Disclaimer](#-disclaimer)
 
 
 <br>
@@ -138,6 +138,15 @@ If you are a developer who would like to contribute to the project, please fork 
 ### Additional Contributors & Acknowledgements
 Hirutso Enni, Kurt Jensen, Dan Falck, Dan Heeks, Brad Collette, Michael Haberler, dhull, jonathanwin, Leemon Baird, Devon (Gorialis) R, Steven Fortune, Bill Simons, Carson Farmer, domlysz
 
+## 🪪 License
+BlenderCAM is licensed under GPLv3, __UNLESS OTHERWISE INDICATED__.
+
+Most files have been written specifically for this addon, though some use code from other sources, see the file docstring a the top of each file for attribution and license information.
+
+If you wish to contribute to the addon, your code must be GPL or a more permissive license (e.g.: MIT, Public Domain).
+
+Please ensure that you read and abide by the license terms given for each file.
+
 ## 🤕 DISCLAIMER
 > [!WARNING]
 THE AUTHORS OF THIS SOFTWARE ACCEPT ABSOLUTELY NO LIABILITY FOR
@@ -154,5 +163,3 @@ from all motors, etc, before persons enter any danger area.
 machinery must be designed to comply with local and national safety
 codes, and the authors of this software can not, and do not, take
 any responsibility for such compliance.
-
-This software is released under the GPLv2.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 - - -
 
-### •  [About](#About)  •  [How to Use](#-how-to-use-wiki)  •  [Features](#-features)  •  [Post-Processors](#-post-processors)  •  [Files](#-files-organisation)  •  [Contributing](#-contributing)  •  [License](#-license)  •  [Disclaimer](#-disclaimer)  •
+### • [About](#About) • [How to Use](#-how-to-use-wiki) • [Features](#-features) • [Post-Processors](#-post-processors) • [Files](#-files-organisation) • [Contributing](#-contributing) • [License](#-license) • [Disclaimer](#-disclaimer) •
 
 - - - 
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@
 
 - - -
 
-
 ### An Open Source Solution for Artistic or Industrial CAM with Blender 3D
-
-
 
 [![Chat on Matrix](https://img.shields.io/matrix/blendercam:matrix.org?label=Chat%20on%20Matrix)](https://riot.im/app/#/room/#blendercam:matrix.org)
 [![Chat on Freenode](https://img.shields.io/badge/chat-on%20freenode-brightgreen.svg)](http://webchat.freenode.net/?channels=%23blendercam)
@@ -19,22 +16,22 @@
 ![Size](https://img.shields.io/github/repo-size/vilemduha/blendercam)
 ![License](https://img.shields.io/github/license/vilemduha/blendercam)
 
-<br>
+- - -
 
+### •  [About](#About)  •  [How to Use](#-how-to-use-wiki)  •  [Features](#-features)  •  [Post-Processors](#-post-processors)  •  [Files](#-files-organisation)  •  [Contributing](#-contributing)  •  [License](#-license)  •  [Disclaimer](#-disclaimer)  •
 
-[About](#About) • [How to Use](#-how-to-use-wiki) • [Features](#-features) • [Post-Processors](#-post-processors) • [Files](#-files-organisation) • [Contributing](#-contributing) • [License](#-license) • [Disclaimer](#-disclaimer)
-
-
-<br>
+- - - 
 
 ![BlenderCAM](documentation/images/suzanne.gif)
+
+- - -
 
 </div>
 
 ## 👁️ About
 BlenderCAM is an add-on for the free open-source [Blender 3D package](https://www.blender.org/).
 
-It offers an open source solution for [CAM _(Computer Aided Machining)_](https://en.wikipedia.org/wiki/Computer-aided_manufacturing) toolpath generation, simulation and [G-code](https://en.wikipedia.org/wiki/G-code) export.
+It offers an open source solution for [CAM _(Computer Aided Machining)_](https://en.wikipedia.org/wiki/Computer-aided_manufacturing) toolpath creation, simulation and [G-code](https://en.wikipedia.org/wiki/G-code) generation and export.
 
 It has been used for many milling projects _(artistic, personal, commercial and industrial)_ since its creation in 2012, and is actively developed. 
 
@@ -127,6 +124,8 @@ BlenderCAM works on Windows or Linux.
 
 Originally created by [Vilem Novak](https://github.com/vilemduha), the addon is currently maintained by [Alain Pelletier](https://github.com/pppalain) and a team of contributors. 
 
+If you wish to contribute to the addon, your code must be GPL or a more permissive license (e.g.: MIT, Public Domain).
+
 If you are a developer who would like to contribute to the project, please fork and open pull requests.
 
 > [!TIP]
@@ -143,11 +142,10 @@ Hirutso Enni, Kurt Jensen, Dan Falck, Dan Heeks, Brad Collette, Michael Haberler
 ## 🪪 License
 BlenderCAM is licensed under GPLv3, __UNLESS OTHERWISE INDICATED__.
 
-Most files have been written specifically for this addon, though some use code from other sources, see the file docstring a the top of each file for attribution and license information.
-
-If you wish to contribute to the addon, your code must be GPL or a more permissive license (e.g.: MIT, Public Domain).
-
-Please ensure that you read and abide by the license terms given for each file.
+> [!NOTE]
+> Some files in this addon use code from other sources, see the file docstring a the top of each file for attribution and license information.
+> 
+> Please ensure that you read and abide by the license terms given for each file.
 
 ## 🤕 DISCLAIMER
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 
 [![Chat on Matrix](https://img.shields.io/matrix/blendercam:matrix.org?label=Chat%20on%20Matrix)](https://riot.im/app/#/room/#blendercam:matrix.org)
 [![Chat on Freenode](https://img.shields.io/badge/chat-on%20freenode-brightgreen.svg)](http://webchat.freenode.net/?channels=%23blendercam)
-[![Chat on Freenode](https://img.shields.io/github/issues/vilemduha/blendercam)](https://github.com/vilemduha/blendercam)
+
+[![Issues](https://img.shields.io/github/issues/vilemduha/blendercam)](https://github.com/vilemduha/blendercam)
 ![Last commit](https://img.shields.io/github/last-commit/vilemduha/blendercam)
 ![Contributors](https://img.shields.io/github/contributors/vilemduha/blendercam)
+
 ![Size](https://img.shields.io/github/repo-size/vilemduha/blendercam)
 ![License](https://img.shields.io/github/license/vilemduha/blendercam)
 

--- a/scripts/addons/cam/LICENSE
+++ b/scripts/addons/cam/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -1,23 +1,7 @@
-# blender CAM __init__.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK ****
+"""BlenderCAM '__init__.py' © 2012 Vilem Novak
+
+Import Modules, bl_info, Register and Unregister Classes
+"""
 
 # Python Standard Library
 import subprocess
@@ -199,7 +183,7 @@ from .utils import (
 bl_info = {
     "name": "BlenderCAM - G-code Generation Tools",
     "author": "Vilem Novak & Contributors",
-    "version":(1,0,19),
+    "version": (1, 0, 19),
     "blender": (3, 6, 0),
     "location": "Properties > render",
     "description": "Generate Machining Paths for CNC",

--- a/scripts/addons/cam/async_op.py
+++ b/scripts/addons/cam/async_op.py
@@ -1,3 +1,9 @@
+"""BlenderCAM 'async_op.py'
+
+Functions and Classes to allow asynchronous updates.
+Used to report progress during path calculation.
+"""
+
 import sys
 import types
 

--- a/scripts/addons/cam/autoupdate.py
+++ b/scripts/addons/cam/autoupdate.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'autoupdate.py'
+
+Classes to check for, download and install BlenderCAM updates.
+"""
+
 import calendar
 from datetime import date
 import io

--- a/scripts/addons/cam/basrelief.py
+++ b/scripts/addons/cam/basrelief.py
@@ -1,3 +1,9 @@
+"""BlenderCAM 'basrelief.py'
+
+Module to allow the creation of reliefs from Images or View Layers.
+(https://en.wikipedia.org/wiki/Relief#Bas-relief_or_low_relief)
+"""
+
 from math import (
     ceil,
     floor,

--- a/scripts/addons/cam/bridges.py
+++ b/scripts/addons/cam/bridges.py
@@ -1,24 +1,9 @@
-# blender CAM utils.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
-# here is the bridges functionality of Blender CAM. The functions here are called with operators defined from ops.py.
+"""BlenderCAM 'bridges.py' © 2012 Vilem Novak
+
+Functions to add Bridges / Tabs to meshes or curves.
+Called with Operators defined in 'ops.py'
+"""
+
 from math import (
     hypot,
     pi,

--- a/scripts/addons/cam/cam_chunk.py
+++ b/scripts/addons/cam/cam_chunk.py
@@ -1,23 +1,7 @@
-# blender CAM chunk.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'chunk.py' © 2012 Vilem Novak
+
+Classes and Functions to build, store and optimize CAM path chunks.
+"""
 
 from math import (
     ceil,

--- a/scripts/addons/cam/cam_operation.py
+++ b/scripts/addons/cam/cam_operation.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'cam_operation.py'
+
+All properties of a single CAM Operation.
+"""
+
 from math import pi
 
 import numpy

--- a/scripts/addons/cam/chain.py
+++ b/scripts/addons/cam/chain.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'chain.py'
+
+All properties of a CAM Chain (a series of Operations), and the Chain's Operation reference.
+"""
+
 from bpy.props import (
     BoolProperty,
     CollectionProperty,

--- a/scripts/addons/cam/collision.py
+++ b/scripts/addons/cam/collision.py
@@ -1,23 +1,8 @@
-# blender CAM collision.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'collision.py' © 2012 Vilem Novak
+
+Functions for Bullet and Cutter collision checks.
+"""
+
 from math import (
     cos,
     pi,
@@ -318,7 +303,7 @@ def cleanupBulletCollision(o):
 
 
 def getSampleBullet(cutter, x, y, radius, startz, endz):
-    """collision test for 3 axis milling. Is simplified compared to the full 3d test"""
+    """Collision Test for 3 Axis Milling. Is Simplified Compared to the Full 3D Test"""
     scene = bpy.context.scene
     pos = scene.rigidbody_world.convex_sweep_test(cutter, (x * BULLET_SCALE, y * BULLET_SCALE, startz * BULLET_SCALE),
                                                   (x * BULLET_SCALE, y * BULLET_SCALE, endz * BULLET_SCALE))

--- a/scripts/addons/cam/constants.py
+++ b/scripts/addons/cam/constants.py
@@ -1,5 +1,7 @@
+"""BlenderCAM 'constants.py'
 
-# Package to store all constants of BlenderCAM
+Package to store all constants of BlenderCAM.
+"""
 
 # PRECISION is used in most operations
 PRECISION = 5
@@ -10,8 +12,9 @@ MAX_OPERATION_TIME = 3200000000  # seconds
 
 G64_INCOMPATIBLE_MACHINES = ['GRBL']
 
+# Upscale factor for higher precision from Bullet library - (Rigidbody Collision World)
 BULLET_SCALE = 10000
-# this is a constant for scaling the rigidbody collision world for higher precision from bullet library
+
+# Cutter object must be present in the scene, so we need to put it aside for sweep collisions,
+# otherwise it collides with itself.
 CUTTER_OFFSET = (-5 * BULLET_SCALE, -5 * BULLET_SCALE, -5 * BULLET_SCALE)
-# the cutter object has to be present in the scene , so we need to put it aside for sweep collisions,
-# otherwise it collides itself.

--- a/scripts/addons/cam/curvecamcreate.py
+++ b/scripts/addons/cam/curvecamcreate.py
@@ -1,23 +1,8 @@
-# blender CAM ops.py (c) 2022 Alain Pelletier
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 3
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'curvecamcreate.py' © 2021, 2022 Alain Pelletier
+
+Operators to create a number of predefined curve objects.
+"""
+
 from math import (
     degrees,
     hypot,

--- a/scripts/addons/cam/curvecamequation.py
+++ b/scripts/addons/cam/curvecamequation.py
@@ -1,23 +1,8 @@
-# blender CAM curvecamequation.py (c) 2021 Alain Pelletier
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 3
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'curvecamequation.py' © 2021, 2022 Alain Pelletier
+
+Operators to create a number of geometric shapes with curves.
+"""
+
 from math import pi
 
 from Equation import Expression

--- a/scripts/addons/cam/curvecamtools.py
+++ b/scripts/addons/cam/curvecamtools.py
@@ -1,25 +1,8 @@
-# blender CAM ops.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'curvecamtools.py' © 2012 Vilem Novak, 2021 Alain Pelletier
 
-# blender operators definitions are in this file. They mostly call the functions from utils.py
+Operators that perform various functions on existing curves.
+"""
+
 from math import (
     pi,
     tan

--- a/scripts/addons/cam/engine.py
+++ b/scripts/addons/cam/engine.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'engine.py'
+
+Engine definition, options and panels.
+"""
+
 from bl_ui.properties_material import (
     EEVEE_MATERIAL_PT_context_material,
     EEVEE_MATERIAL_PT_settings,

--- a/scripts/addons/cam/exception.py
+++ b/scripts/addons/cam/exception.py
@@ -1,2 +1,8 @@
+"""BlenderCAM 'exception.py'
+
+Generic CAM Exception class.
+"""
+
+
 class CamException(Exception):
     pass

--- a/scripts/addons/cam/gcodeimportparser.py
+++ b/scripts/addons/cam/gcodeimportparser.py
@@ -1,22 +1,9 @@
-#!/usr/bin/env python
-# https://github.com/jonathanwin/yagv with no licence
-# code modified from YAGV -yet another gcode viewer
-# will assume release GNU release
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 3
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'gcodeimportparser.py'
+
+Code modified from YAGV (Yet Another G-code Viewer) - https://github.com/jonathanwin/yagv
+No license terms found in YAGV repo, will assume GNU release
+"""
+
 import math
 
 import numpy as np
@@ -27,7 +14,7 @@ np.set_printoptions(suppress=True)  # suppress scientific notation in subdivide 
 
 
 def import_gcode(context, filepath):
-    print("running read_some_data...")
+    print("Running read_some_data...")
 
     scene = context.scene
     mytool = scene.cam_import_gcode

--- a/scripts/addons/cam/gcodepath.py
+++ b/scripts/addons/cam/gcodepath.py
@@ -1,25 +1,9 @@
-# blender CAM gcodepath.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'gcodepath.py' © 2012 Vilem Novak
 
-# here is the Gcode generaton
+Generate and Export G-Code based on scene, machine, chain, operation and path settings.
+"""
+
+# G-code Generaton
 from math import (
     ceil,
     floor,

--- a/scripts/addons/cam/image_utils.py
+++ b/scripts/addons/cam/image_utils.py
@@ -1,23 +1,7 @@
-# blender CAM image_utils.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'image_utils.py' © 2012 Vilem Novak
+
+Functions to render, save, convert and analyze image data.
+"""
 
 from math import (
     acos,

--- a/scripts/addons/cam/involute_gear.py
+++ b/scripts/addons/cam/involute_gear.py
@@ -1,67 +1,66 @@
+"""BlenderCAM 'involute_gear.py' Ported by Alain Pelletier Jan 2022
+
+from:
+Public Domain Parametric Involute Spur Gear (and involute helical gear and involute rack)
+version 1.1
+by Leemon Baird, 2011, Leemon@Leemon.com
+http:www.thingiverse.com/thing:5505
+
+This file is public domain.  Use it for any purpose, including commercial
+applications.  Attribution would be nice, but is not required.  There is
+no warranty of any kind, including its correctness, usefulness, or safety.
+
+This is parameterized involute spur (or helical) gear.  It is much simpler and less powerful than
+others on Thingiverse.  But it is public domain.  I implemented it from scratch from the
+descriptions and equations on Wikipedia and the web, using Mathematica for calculations and testing,
+and I now release it into the public domain.
+
+    http:en.wikipedia.org/wiki/Involute_gear
+    http:en.wikipedia.org/wiki/Gear
+    http:en.wikipedia.org/wiki/List_of_gear_nomenclature
+    http:gtrebaol.free.fr/doc/catia/spur_gear.html
+    http:www.cs.cmu.edu/~rapidproto/mechanisms/chpt7.html
+
+The module gear() gives an involute spur gear, with reasonable defaults for all the parameters.
+Normally, you should just choose the first 4 parameters, and let the rest be default values.
+The module gear() gives a gear in the XY plane, centered on the origin, with one tooth centered on
+the positive Y axis.  The various functions below it take the same parameters, and return various
+measurements for the gear.  The most important is pitch_radius, which tells how far apart to space
+gears that are meshing, and adendum_radius, which gives the size of the region filled by the gear.
+A gear has a "pitch circle", which is an invisible circle that cuts through the middle of each
+tooth (though not the exact center). In order for two gears to mesh, their pitch circles should
+just touch.  So the distance between their centers should be pitch_radius() for one, plus pitch_radius()
+for the other, which gives the radii of their pitch circles.
+
+In order for two gears to mesh, they must have the same mm_per_tooth and pressure_angle parameters.
+mm_per_tooth gives the number of millimeters of arc around the pitch circle covered by one tooth and one
+space between teeth.  The pitch angle controls how flat or bulged the sides of the teeth are.  Common
+values include 14.5 degrees and 20 degrees, and occasionally 25.  Though I've seen 28 recommended for
+plastic gears. Larger numbers bulge out more, giving stronger teeth, so 28 degrees is the default here.
+
+The ratio of number_of_teeth for two meshing gears gives how many times one will make a full
+revolution when the the other makes one full revolution.  If the two numbers are coprime (i.e.
+are not both divisible by the same number greater than 1), then every tooth on one gear
+will meet every tooth on the other, for more even wear.  So coprime numbers of teeth are good.
+
+The module rack() gives a rack, which is a bar with teeth.  A rack can mesh with any
+gear that has the same mm_per_tooth and pressure_angle.
+
+Some terminology:
+The outline of a gear is a smooth circle (the "pitch circle") which has mountains and valleys
+added so it is toothed.  So there is an inner circle (the "root circle") that touches the
+base of all the teeth, an outer circle that touches the tips of all the teeth,
+and the invisible pitch circle in between them.  There is also a "base circle", which can be smaller than
+all three of the others, which controls the shape of the teeth.  The side of each tooth lies on the path
+that the end of a string would follow if it were wrapped tightly around the base circle, then slowly unwound.
+That shape is an "involute", which gives this type of gear its name.
+
+An involute spur gear, with reasonable defaults for all the parameters.
+Normally, you should just choose the first 4 parameters, and let the rest be default values.
+Meshing gears must match in mm_per_tooth, pressure_angle, and twist,
+and be separated by the sum of their pitch radii, which can be found with pitch_radius().
 """
-//////////////////////////////////////////////////////////////////////////////////////////////
-// Public Domain Parametric Involute Spur Gear (and involute helical gear and involute rack)
-// version 1.1
-// by Leemon Baird, 2011, Leemon@Leemon.com
-//http://www.thingiverse.com/thing:5505
-//
-// This file is public domain.  Use it for any purpose, including commercial
-// applications.  Attribution would be nice, but is not required.  There is
-// no warranty of any kind, including its correctness, usefulness, or safety.
-//
-// This is parameterized involute spur (or helical) gear.  It is much simpler and less powerful than
-// others on Thingiverse.  But it is public domain.  I implemented it from scratch from the
-// descriptions and equations on Wikipedia and the web, using Mathematica for calculations and testing,
-// and I now release it into the public domain.
-//
-//        http://en.wikipedia.org/wiki/Involute_gear
-//        http://en.wikipedia.org/wiki/Gear
-//        http://en.wikipedia.org/wiki/List_of_gear_nomenclature
-//        http://gtrebaol.free.fr/doc/catia/spur_gear.html
-//        http://www.cs.cmu.edu/~rapidproto/mechanisms/chpt7.html
-//
-// The module gear() gives an involute spur gear, with reasonable defaults for all the parameters.
-// Normally, you should just choose the first 4 parameters, and let the rest be default values.
-// The module gear() gives a gear in the XY plane, centered on the origin, with one tooth centered on
-// the positive Y axis.  The various functions below it take the same parameters, and return various
-// measurements for the gear.  The most important is pitch_radius, which tells how far apart to space
-// gears that are meshing, and adendum_radius, which gives the size of the region filled by the gear.
-// A gear has a "pitch circle", which is an invisible circle that cuts through the middle of each
-// tooth (though not the exact center). In order for two gears to mesh, their pitch circles should
-// just touch.  So the distance between their centers should be pitch_radius() for one, plus pitch_radius()
-// for the other, which gives the radii of their pitch circles.
-//
-// In order for two gears to mesh, they must have the same mm_per_tooth and pressure_angle parameters.
-// mm_per_tooth gives the number of millimeters of arc around the pitch circle covered by one tooth and one
-// space between teeth.  The pitch angle controls how flat or bulged the sides of the teeth are.  Common
-// values include 14.5 degrees and 20 degrees, and occasionally 25.  Though I've seen 28 recommended for
-// plastic gears. Larger numbers bulge out more, giving stronger teeth, so 28 degrees is the default here.
-//
-// The ratio of number_of_teeth for two meshing gears gives how many times one will make a full
-// revolution when the the other makes one full revolution.  If the two numbers are coprime (i.e.
-// are not both divisible by the same number greater than 1), then every tooth on one gear
-// will meet every tooth on the other, for more even wear.  So coprime numbers of teeth are good.
-//
-// The module rack() gives a rack, which is a bar with teeth.  A rack can mesh with any
-// gear that has the same mm_per_tooth and pressure_angle.
-//
-// Some terminology:
-// The outline of a gear is a smooth circle (the "pitch circle") which has mountains and valleys
-// added so it is toothed.  So there is an inner circle (the "root circle") that touches the
-// base of all the teeth, an outer circle that touches the tips of all the teeth,
-// and the invisible pitch circle in between them.  There is also a "base circle", which can be smaller than
-// all three of the others, which controls the shape of the teeth.  The side of each tooth lies on the path
-// that the end of a string would follow if it were wrapped tightly around the base circle, then slowly unwound.
-// That shape is an "involute", which gives this type of gear its name.
-//
-//////////////////////////////////////////////////////////////////////////////////////////////
 
-//An involute spur gear, with reasonable defaults for all the parameters.
-//Normally, you should just choose the first 4 parameters, and let the rest be default values.
-//Meshing gears must match in mm_per_tooth, pressure_angle, and twist,
-//and be separated by the sum of their pitch radii, which can be found with pitch_radius(). """
-
-# ported to Blendercam by Alain Pelletier Jan 2022
 from math import (
     acos,
     cos,

--- a/scripts/addons/cam/joinery.py
+++ b/scripts/addons/cam/joinery.py
@@ -1,23 +1,7 @@
-# blender CAM ops.py (c) 2021 Alain Pelletier
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'joinery.py' © 2021 Alain Pelletier
+
+Functions to create various woodworking joints - mortise, finger etc.
+"""
 
 # blender operators definitions are in this file. They mostly call the functions from utils.py
 from math import (

--- a/scripts/addons/cam/machine_settings.py
+++ b/scripts/addons/cam/machine_settings.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'machine_settings.py'
+
+All CAM machine properties.
+"""
+
 from bpy.props import (
     BoolProperty,
     EnumProperty,

--- a/scripts/addons/cam/numba_wrapper.py
+++ b/scripts/addons/cam/numba_wrapper.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'numba_wrapper.py'
+
+Patch to ensure functions will run if numba is unavailable.
+"""
+
 try:
     from numba import jit, prange
     print("numba: yes")

--- a/scripts/addons/cam/opencamlib/oclSample.py
+++ b/scripts/addons/cam/opencamlib/oclSample.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'oclSample.py'
+
+Functions to sample mesh or curve data for OpenCAMLib processing.
+"""
+
 from math import (
     radians,
     tan

--- a/scripts/addons/cam/opencamlib/opencamlib.py
+++ b/scripts/addons/cam/opencamlib/opencamlib.py
@@ -1,4 +1,8 @@
-# used by OpenCAMLib sampling
+"""BlenderCAM 'oclSample.py'
+
+Functions used by OpenCAMLib sampling.
+"""
+
 import os
 from subprocess import call
 import tempfile

--- a/scripts/addons/cam/ops.py
+++ b/scripts/addons/cam/ops.py
@@ -1,25 +1,9 @@
-# blender CAM ops.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'ops.py' © 2012 Vilem Novak
 
-# blender operators definitions are in this file. They mostly call the functions from utils.py
+Blender Operator definitions are in this file.
+They mostly call the functions from 'utils.py'
+"""
+
 import os
 import subprocess
 import textwrap

--- a/scripts/addons/cam/pack.py
+++ b/scripts/addons/cam/pack.py
@@ -1,23 +1,12 @@
-# blender CAM pack.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'pack.py' © 2012 Vilem Novak
+
+Takes all selected curves, converts them to polygons, offsets them by the pre-set margin
+then chooses a starting location possibly inside the already occupied area and moves and rotates the
+polygon out of the occupied area if one or more positions are found where the poly doesn't overlap,
+it is placed and added to the occupied area - allpoly
+Very slow and STUPID, a collision algorithm would be much much faster...
+"""
+
 from math import pi
 import random
 import time
@@ -48,15 +37,6 @@ from . import (
     simple,
     utils,
 )
-
-
-# this algorithm takes all selected curves,
-# converts them to polygons,
-# offsets them by the pre-set margin
-# then chooses a starting location possibly inside the allready occupied area and moves and rotates the
-# polygon out of the occupied area if one or more positions are found where the poly doesn't overlap,
-# it is placed and added to the occupied area - allpoly
-# this algorithm is very slow and STUPID, a collision algorithm would be much much faster...
 
 
 def srotate(s, r, x, y):

--- a/scripts/addons/cam/parametric.py
+++ b/scripts/addons/cam/parametric.py
@@ -1,34 +1,35 @@
-# MIT License
-#
-# Copyright (c) 2019 Devon (Gorialis) R
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-#
-#
-#
-# Create a Blender curve from a 3D parametric function.
-# This allows for a 3D plot to be made of the function, which can be converted into a mesh.
-#
-# I have documented the inner workings here, but if you're not interested and just want to
-# suit this to your own function, scroll down to the bottom and edit the `f(t)` function and
-# the iteration count to your liking.
-#
-# This code has been checked to work on Blender 2.92.
+"""BlenderCAM 'parametric.py' © 2019 Devon (Gorialis) R
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+Summary:
+Create a Blender curve from a 3D parametric function.
+This allows for a 3D plot to be made of the function, which can be converted into a mesh.
+
+I have documented the inner workings here, but if you're not interested and just want to
+suit this to your own function, scroll down to the bottom and edit the `f(t)` function and
+the iteration count to your liking.
+
+This code has been checked to work on Blender 2.92.
+"""
+
 from math import pow
 
 import bpy

--- a/scripts/addons/cam/pattern.py
+++ b/scripts/addons/cam/pattern.py
@@ -1,23 +1,8 @@
-# blender CAM pattern.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'pattern.py' © 2012 Vilem Novak
+
+Functions to read CAM path patterns and return CAM path chunks.
+"""
+
 from math import (
     ceil,
     floor,

--- a/scripts/addons/cam/pie_menu/active_op/pie_area.py
+++ b/scripts/addons/cam/pie_menu/active_op/pie_area.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_area.py'
+
+'Operation Area' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/active_op/pie_cutter.py
+++ b/scripts/addons/cam/pie_menu/active_op/pie_cutter.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_cutter.py'
+
+'Operation Cutter' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/active_op/pie_feedrate.py
+++ b/scripts/addons/cam/pie_menu/active_op/pie_feedrate.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_feedrate.py'
+
+'Operation Feedrate' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/active_op/pie_gcode.py
+++ b/scripts/addons/cam/pie_menu/active_op/pie_gcode.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_gcode.py'
+
+'Operation G-code' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/active_op/pie_movement.py
+++ b/scripts/addons/cam/pie_menu/active_op/pie_movement.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_movement.py'
+
+'Operation Movement' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/active_op/pie_operation.py
+++ b/scripts/addons/cam/pie_menu/active_op/pie_operation.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_operation.py'
+
+'Active Operation' Pie Menu - Parent to all active_op Pie Menus
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/active_op/pie_optimisation.py
+++ b/scripts/addons/cam/pie_menu/active_op/pie_optimisation.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_optimisation.py'
+
+'Operation Optimisation' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/active_op/pie_setup.py
+++ b/scripts/addons/cam/pie_menu/active_op/pie_setup.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_setup.py'
+
+'Operation Setup' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/pie_cam.py
+++ b/scripts/addons/cam/pie_menu/pie_cam.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_cam.py'
+
+'BlenderCAM' Pie Menu - Parent to all other CAM Pie Menus
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/pie_chains.py
+++ b/scripts/addons/cam/pie_menu/pie_chains.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_chains.py'
+
+'Operations & Chains' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/pie_curvecreators.py
+++ b/scripts/addons/cam/pie_menu/pie_curvecreators.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_curvecreators.py'
+
+'Curve Creators' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/pie_curvetools.py
+++ b/scripts/addons/cam/pie_menu/pie_curvetools.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_curvetools.py'
+
+'Curve Tools' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/pie_info.py
+++ b/scripts/addons/cam/pie_menu/pie_info.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_info.py'
+
+'Info' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/pie_machine.py
+++ b/scripts/addons/cam/pie_menu/pie_machine.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_machine.py'
+
+'Machine Settings' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/pie_material.py
+++ b/scripts/addons/cam/pie_menu/pie_material.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_material.py'
+
+'Material Size & Position' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/pie_menu/pie_pack_slice_relief.py
+++ b/scripts/addons/cam/pie_menu/pie_pack_slice_relief.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pie_pack_slice_relief.py'
+
+'Pack, Slice and Bas Relief' Pie Menu
+"""
+
 import bpy
 from bpy.types import Menu
 

--- a/scripts/addons/cam/polygon_utils_cam.py
+++ b/scripts/addons/cam/polygon_utils_cam.py
@@ -1,23 +1,7 @@
-# blender CAM polygon_utils_cam.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'polygon_utils_cam.py' © 2012 Vilem Novak
+
+Functions to handle shapely operations and conversions - curve, coords, polygon
+"""
 
 from math import pi
 

--- a/scripts/addons/cam/preferences.py
+++ b/scripts/addons/cam/preferences.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'preferences.py'
+
+Class to store all Addon preferences.
+"""
+
 from bpy.props import (
     BoolProperty,
     EnumProperty,

--- a/scripts/addons/cam/preset_managers.py
+++ b/scripts/addons/cam/preset_managers.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'preset_managers.py'
+
+Operators and Menus for CAM Machine, Cutter and Operation Presets.
+"""
+
 import bpy
 from bl_operators.presets import AddPresetBase
 from bpy.types import (

--- a/scripts/addons/cam/puzzle_joinery.py
+++ b/scripts/addons/cam/puzzle_joinery.py
@@ -1,25 +1,8 @@
-# blender CAM ops.py (c) 2021 Alain Pelletier
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'puzzle_joinery.py' © 2021 Alain Pelletier
 
-# blender operators definitions are in this file. They mostly call the functions from curvecamcreate.py
+Functions to add various puzzle joints as curves.
+"""
+
 from math import (
     cos,
     degrees,

--- a/scripts/addons/cam/simple.py
+++ b/scripts/addons/cam/simple.py
@@ -1,23 +1,8 @@
-# blender CAM simple.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'simple.py' © 2012 Vilem Novak
+
+Various helper functions, less complex than those found in the 'utils' files.
+"""
+
 from math import (
     hypot,
     pi,

--- a/scripts/addons/cam/simulation.py
+++ b/scripts/addons/cam/simulation.py
@@ -1,25 +1,8 @@
-# blender CAM utils.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'simulation.py' © 2012 Vilem Novak
 
-# here is the main functionality of Blender CAM. The functions here are called with operators defined in ops.py.
+Functions to generate a mesh simulation from CAM Chain / Operation data.
+"""
+
 import math
 import time
 

--- a/scripts/addons/cam/slice.py
+++ b/scripts/addons/cam/slice.py
@@ -1,26 +1,8 @@
-# blender CAM slice.py (c) 2021 Alain Pelletier
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'slice.py' © 2021 Alain Pelletier
 
-# very simple slicing for 3d meshes, useful for plywood cutting.
-# completely rewritten April 2021
+Very simple slicing for 3D meshes, useful for plywood cutting.
+Completely rewritten April 2021.
+"""
 
 import bpy
 from bpy.props import (

--- a/scripts/addons/cam/strategy.py
+++ b/scripts/addons/cam/strategy.py
@@ -1,25 +1,9 @@
-# blender CAM strategy.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'strategy.py' © 2012 Vilem Novak
 
-# here is the strategy functionality of Blender CAM. The functions here are called with operators defined in ops.py.
+Strategy functionality of BlenderCAM - e.g. Cutout, Parallel, Spiral, Waterline
+The functions here are called with operators defined in 'ops.py'
+"""
+
 from math import (
     ceil,
     pi,

--- a/scripts/addons/cam/testing.py
+++ b/scripts/addons/cam/testing.py
@@ -1,23 +1,8 @@
-# blender CAM testing.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'testing.py' © 2012 Vilem Novak
+
+Functions for automated testing.
+"""
+
 import bpy
 
 from .gcodepath import getPath

--- a/scripts/addons/cam/ui.py
+++ b/scripts/addons/cam/ui.py
@@ -1,23 +1,8 @@
-# blender CAM ui.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+"""BlenderCAM 'ui.py' © 2012 Vilem Novak
+
+Panels displayed in the 3D Viewport - Curve Tools, Creators and Import G-code
+"""
+
 from bpy_extras.io_utils import ImportHelper
 from bpy.props import (
     BoolProperty,

--- a/scripts/addons/cam/ui_panels/area.py
+++ b/scripts/addons/cam/ui_panels/area.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'area.py'
+
+'CAM Operation Area' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import Panel
 

--- a/scripts/addons/cam/ui_panels/buttons_panel.py
+++ b/scripts/addons/cam/ui_panels/buttons_panel.py
@@ -1,3 +1,9 @@
+"""BlenderCAM 'buttons_panel.py'
+
+Parent (Mixin) class for all panels in 'ui_panels'
+Sets up polling and operations to show / hide panels based on Interface Level
+"""
+
 import inspect
 
 import bpy

--- a/scripts/addons/cam/ui_panels/chains.py
+++ b/scripts/addons/cam/ui_panels/chains.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'chains.py'
+
+'CAM Chains' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import UIList, Panel
 

--- a/scripts/addons/cam/ui_panels/cutter.py
+++ b/scripts/addons/cam/ui_panels/cutter.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'cutter.py'
+
+'CAM Cutter' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import Panel
 

--- a/scripts/addons/cam/ui_panels/feedrate.py
+++ b/scripts/addons/cam/ui_panels/feedrate.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'feedrate.py'
+
+'CAM Feedrate' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import Panel
 

--- a/scripts/addons/cam/ui_panels/gcode.py
+++ b/scripts/addons/cam/ui_panels/gcode.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'gcode.py'
+
+'CAM G-code Options' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import Panel
 

--- a/scripts/addons/cam/ui_panels/info.py
+++ b/scripts/addons/cam/ui_panels/info.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'info.py'
+
+'CAM Info & Warnings' properties and panel in Properties > Render
+"""
+
 import bpy
 from bpy.props import (
     StringProperty,

--- a/scripts/addons/cam/ui_panels/interface.py
+++ b/scripts/addons/cam/ui_panels/interface.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'interface.py'
+
+'Interface' properties and panel in Properties > Render
+"""
+
 import bpy
 from bpy.props import EnumProperty
 from bpy.types import (

--- a/scripts/addons/cam/ui_panels/machine.py
+++ b/scripts/addons/cam/ui_panels/machine.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'machine.py'
+
+'CAM Machine' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import Panel
 

--- a/scripts/addons/cam/ui_panels/material.py
+++ b/scripts/addons/cam/ui_panels/material.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'material.py'
+
+'CAM Material' properties and panel in Properties > Render
+"""
+
 import bpy
 from bpy.props import (
     BoolProperty,

--- a/scripts/addons/cam/ui_panels/movement.py
+++ b/scripts/addons/cam/ui_panels/movement.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'movement.py'
+
+'CAM Movement' properties and panel in Properties > Render
+"""
+
 from math import pi
 
 import bpy

--- a/scripts/addons/cam/ui_panels/op_properties.py
+++ b/scripts/addons/cam/ui_panels/op_properties.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'op_properties.py'
+
+'CAM Operation Setup' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import Panel
 

--- a/scripts/addons/cam/ui_panels/operations.py
+++ b/scripts/addons/cam/ui_panels/operations.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'operations.py'
+
+'CAM Operations' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import Panel
 

--- a/scripts/addons/cam/ui_panels/optimisation.py
+++ b/scripts/addons/cam/ui_panels/optimisation.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'optimisation.py'
+
+'CAM Optimisation' properties and panel in Properties > Render
+"""
+
 import bpy
 from bpy.props import (
     BoolProperty,

--- a/scripts/addons/cam/ui_panels/pack.py
+++ b/scripts/addons/cam/ui_panels/pack.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'pack.py'
+
+'Pack Curves on Sheet' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import Panel
 

--- a/scripts/addons/cam/ui_panels/slice.py
+++ b/scripts/addons/cam/ui_panels/slice.py
@@ -1,3 +1,8 @@
+"""BlenderCAM 'slice.py'
+
+'Slice Model to Plywood Sheets' panel in Properties > Render
+"""
+
 import bpy
 from bpy.types import Panel
 

--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -1,26 +1,9 @@
+"""BlenderCAM 'utils.py' © 2012 Vilem Novak
 
-# blender CAM utils.py (c) 2012 Vilem Novak
-#
-# ***** BEGIN GPL LICENSE BLOCK *****
-#
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software Foundation,
-# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-#
-# ***** END GPL LICENCE BLOCK *****
+Main functionality of BlenderCAM.
+The functions here are called with operators defined in 'ops.py'
+"""
 
-# here is the main functionality of Blender CAM. The functions here are called with operators defined in ops.py.
 from math import (
     ceil,
     pi

--- a/scripts/addons/cam/version.py
+++ b/scripts/addons/cam/version.py
@@ -1,1 +1,6 @@
-__version__=(1,0,19)
+"""BlenderCAM 'version.py'
+
+Addon version, read and incremented by Github Actions
+"""
+
+__version__ = (1, 0, 19)

--- a/scripts/addons/cam/voronoi.py
+++ b/scripts/addons/cam/voronoi.py
@@ -1,66 +1,63 @@
-# -*- coding: utf-8 -*-
+"""BlenderCAM 'voronoi.py'
 
-#############################################################################
-#
-# Voronoi diagram calculator/ Delaunay triangulator
-#
-# - Voronoi Diagram Sweepline algorithm and C code by Steven Fortune, 1987, http://ect.bell-labs.com/who/sjf/
-# - Python translation to file voronoi.py by Bill Simons, 2005, http://www.oxfish.com/
-# - Additional changes for QGIS by Carson Farmer added November 2010
-# - 2012 Ported to Python 3 and additional clip functions by domlysz at gmail.com
-#
-# Calculate Delaunay triangulation or the Voronoi polygons for a set of
-# 2D input points.
-#
-# Derived from code bearing the following notice:
-#
-#  The author of this software is Steven Fortune.  Copyright (c) 1994 by AT&T
-#  Bell Laboratories.
-#  Permission to use, copy, modify, and distribute this software for any
-#  purpose without fee is hereby granted, provided that this entire notice
-#  is included in all copies of any software which is or includes a copy
-#  or modification of this software and in all copies of the supporting
-#  documentation for such software.
-#  THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
-#  WARRANTY.  IN PARTICULAR, NEITHER THE AUTHORS NOR AT&T MAKE ANY
-#  REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY
-#  OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
-#
-# Comments were incorporated from Shane O'Sullivan's translation of the
-# original code into C++ (http://mapviewer.skynet.ie/voronoi.html)
-#
-# Steve Fortune's homepage: http://netlib.bell-labs.com/cm/cs/who/sjf/index.html
-#
-#
-#
-# For programmatic use two functions are available:
-#
-#	computeVoronoiDiagram(points, xBuff, yBuff, polygonsOutput=False, formatOutput=False) :
-#	Takes :
-#		- a list of point objects (which must have x and y fields).
-#		- x and y buffer values which are the expansion percentages of the bounding box rectangle including all input points.
-#		Returns :
-#		- With default options :
-#		  A list of 2-tuples, representing the two points of each Voronoi diagram edge.
-#		  Each point contains 2-tuples which are the x,y coordinates of point.
-#		  if formatOutput is True, returns :
-#				- a list of 2-tuples, which are the x,y coordinates of the Voronoi diagram vertices.
-#				- and a list of 2-tuples (v1, v2) representing edges of the Voronoi diagram.
-#				  v1 and v2 are the indices of the vertices at the end of the edge.
-#		- If polygonsOutput option is True, returns :
-#		  A dictionary of polygons, keys are the indices of the input points,
-#		  values contains n-tuples representing the n points of each Voronoi diagram polygon.
-#		  Each point contains 2-tuples which are the x,y coordinates of point.
-#		  if formatOutput is True, returns :
-#				- A list of 2-tuples, which are the x,y coordinates of the Voronoi diagram vertices.
-#				- and a dictionary of input points indices. Values contains n-tuples representing the n points of each Voronoi diagram polygon.
-#				  Each tuple contains the vertex indices of the polygon vertices.
-#
-#	computeDelaunayTriangulation(points):
-#		Takes a list of point objects (which must have x and y fields).
-#		Returns a list of 3-tuples: the indices of the points that form a Delaunay triangle.
-#
-#############################################################################
+Voronoi diagram calculator/ Delaunay triangulator
+
+- Voronoi Diagram Sweepline algorithm and C code by Steven Fortune, 1987, http://ect.bell-labs.com/who/sjf/
+- Python translation to file voronoi.py by Bill Simons, 2005, http://www.oxfish.com/
+- Additional changes for QGIS by Carson Farmer added November 2010
+- 2012 Ported to Python 3 and additional clip functions by domlysz at gmail.com
+
+Calculate Delaunay triangulation or the Voronoi polygons for a set of
+2D input points.
+
+Derived from code bearing the following notice:
+
+The author of this software is Steven Fortune.  Copyright (c) 1994 by AT&T
+Bell Laboratories.
+Permission to use, copy, modify, and distribute this software for any
+purpose without fee is hereby granted, provided that this entire notice
+is included in all copies of any software which is or includes a copy
+or modification of this software and in all copies of the supporting
+documentation for such software.
+THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTY.  IN PARTICULAR, NEITHER THE AUTHORS NOR AT&T MAKE ANY
+REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY
+OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
+
+Comments were incorporated from Shane O'Sullivan's translation of the
+original code into C++ (http://mapviewer.skynet.ie/voronoi.html)
+
+Steve Fortune's homepage: http://netlib.bell-labs.com/cm/cs/who/sjf/index.html
+
+
+For programmatic use two functions are available:
+
+computeVoronoiDiagram(points, xBuff, yBuff, polygonsOutput=False, formatOutput=False) :
+Takes :
+	- a list of point objects (which must have x and y fields).
+	- x and y buffer values which are the expansion percentages of the bounding box rectangle including all input points.
+	Returns :
+	- With default options :
+	  A list of 2-tuples, representing the two points of each Voronoi diagram edge.
+	  Each point contains 2-tuples which are the x,y coordinates of point.
+	  if formatOutput is True, returns :
+			- a list of 2-tuples, which are the x,y coordinates of the Voronoi diagram vertices.
+			- and a list of 2-tuples (v1, v2) representing edges of the Voronoi diagram.
+			  v1 and v2 are the indices of the vertices at the end of the edge.
+	- If polygonsOutput option is True, returns :
+	  A dictionary of polygons, keys are the indices of the input points,
+	  values contains n-tuples representing the n points of each Voronoi diagram polygon.
+	  Each point contains 2-tuples which are the x,y coordinates of point.
+	  if formatOutput is True, returns :
+			- A list of 2-tuples, which are the x,y coordinates of the Voronoi diagram vertices.
+			- and a dictionary of input points indices. Values contains n-tuples representing the n points of each Voronoi diagram polygon.
+			  Each tuple contains the vertex indices of the polygon vertices.
+
+computeDelaunayTriangulation(points):
+	Takes a list of point objects (which must have x and y fields).
+	Returns a list of 3-tuples: the indices of the points that form a Delaunay triangle.
+"""
+
 import math
 import sys
 


### PR DESCRIPTION
Per discussion in Matrix Dev channel, GPLv2 license has been updated to GPLv3, and is now included in the addon root in addition to the repository root, to ensure everyone will receive a copy, regardless of how they download or install.

GPL blocks have been removed from the files that had them, and a `License` section has been added to the `README`, clarifying that all files are licensed under GPLv3 __UNLESS OTHERWISE INDICATED.__

Header comments (filename, author name, alternative license, source etc) have been formatted for consistency.
Now every file follows this format:
```python
"""BlenderCAM 'filename.py' © 20xx Author Name (if available)

License information (if not GPL)
Brief summary of what is in the file (functions, classes) and what the file does.
Original developer comments. (if available)
"""
```

Small edits to `README` for clarity, consistency and readability.