### PR TITLE
Curve Addons & Version Update

### DIFF
--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -397,18 +397,6 @@ def register() -> None:
     kmi.properties.name = 'VIEW3D_MT_PIE_CAM'
     kmi.active = True
 
-    addons = bpy.context.preferences.addons
-
-    modules = [
-        "curve_tools",
-        "curve_simplify",
-        "add_curve_extra_objects",
-    ]
-
-    for module in modules:
-        if module not in addons:
-            bpy.ops.preferences.addon_enable(module=module)
-
 
 def unregister() -> None:
     for cls in classes:

--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -183,7 +183,7 @@ from .utils import (
 bl_info = {
     "name": "BlenderCAM - G-code Generation Tools",
     "author": "Vilem Novak & Contributors",
-    "version": (1, 0, 19),
+    "version": (1, 0, 20),
     "blender": (3, 6, 0),
     "location": "Properties > render",
     "description": "Generate Machining Paths for CNC",
@@ -396,6 +396,18 @@ def register() -> None:
     )
     kmi.properties.name = 'VIEW3D_MT_PIE_CAM'
     kmi.active = True
+
+    addons = bpy.context.preferences.addons
+
+    modules = [
+        "curve_tools",
+        "curve_simplify",
+        "add_curve_extra_objects",
+    ]
+
+    for module in modules:
+        if module not in addons:
+            bpy.ops.preferences.addon_enable(module=module)
 
 
 def unregister() -> None:

--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -2085,6 +2085,19 @@ def update_zbuffer_image(self, context):
 @bpy.app.handlers.persistent
 def check_operations_on_load(context):
     """Checks Any Broken Computations on Load and Reset Them."""
+
+    addons = bpy.context.preferences.addons
+
+    modules = [
+        "curve_tools",
+        "curve_simplify",
+        "add_curve_extra_objects",
+    ]
+
+    for module in modules:
+        if module not in addons:
+            bpy.ops.preferences.addon_enable(module=module)
+
     s = bpy.context.scene
     for o in s.cam_operations:
         if o.computing:

--- a/scripts/addons/cam/version.py
+++ b/scripts/addons/cam/version.py
@@ -1,6 +1,1 @@
-"""BlenderCAM 'version.py'
-
-Addon version, read and incremented by Github Actions
-"""
-
-__version__ = (1, 0, 19)
+__version__ = (1, 0, 20)


### PR DESCRIPTION
Added logic to the `utils.py` file, in the `check_operations_on_load` function to activate the required curve addons per recent bug report.
Unfortunately, this could not be added to the `register` function to ensure that it would be active at the time of installation as Blender restricts access to context (required to read and update addons in preferences) during registration, so it had to be moved into the post-load handler in `utils.py`. 

The consequence is that the addons will not be activated on install, but only on restarting Blender, like the other adjustments made in `check_operations_on_load`. This could be noted in the installation instructions until a better alternative can be found.

`version.py` updated to remove the docstring header I just added, as I think it screwed up the regex in the addon versioning github action.
D'oh.