### PR TITLE
remove bogus newline from bl_info

### DIFF
--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -184,7 +184,6 @@ bl_info = {
     "name": "BlenderCAM - G-code Generation Tools",
     "author": "Vilem Novak & Contributors",
     "version":(1,0,26),
-
     "blender": (3, 6, 0),
     "location": "Properties > render",
     "description": "Generate Machining Paths for CNC",


### PR DESCRIPTION
Starting Blender from the console produces the following error:
`Syntax error 'ast.parse' can't read: '/Users/stephen/Documents/github/blendercam/scripts/addons/cam/__init__.py'
Traceback (most recent call last):
  File "/Applications/Blender 4.0.2.app/Contents/Resources/4.0/scripts/modules/addon_utils.py", line 123, in _fake_module
    ast_data = ast.parse(data, filename=mod_path)
  File "/Applications/Blender 4.0.2.app/Contents/Resources/4.0/python/lib/python3.10/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
  File "/Users/stephen/Documents/github/blendercam/scripts/addons/cam/__init__.py", line 1
    """BlenderCAM '__init__.py' © 2012 Vilem Novak
              ^
SyntaxError: '{' was never closed
fake_module: addon missing 'bl_info' gives bad performance!: '/Users/stephen/Documents/github/blendercam/scripts/addons/cam/__init__.py'`

The solution is to remove the extra newline in the bl_info