### PR TITLE
camtool improvement

### DIFF
--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -69,7 +69,7 @@ from .curvecamtools import (
     CamCurveRemoveDoubles,
     CamMeshGetPockets,
     CamOffsetSilhouete,
-    CamObjectSilhouete,
+    #CamObjectSilhouete,
 )
 from .engine import (
     CNCCAM_ENGINE,
@@ -231,7 +231,7 @@ classes = [
     CamCurveRemoveDoubles,
     CamMeshGetPockets,
     CamOffsetSilhouete,
-    CamObjectSilhouete,
+    #CamObjectSilhouete,
 
     # .engine
     CNCCAM_ENGINE,

--- a/scripts/addons/cam/pie_menu/pie_curvetools.py
+++ b/scripts/addons/cam/pie_menu/pie_curvetools.py
@@ -33,7 +33,7 @@ class VIEW3D_MT_PIE_CurveTools(Menu):
         # Bottom
         box = pie.box()
         column = box.column(align=True)
-        column.operator("object.silhouete")
+        #column.operator("object.silhouete")
         column.operator("object.silhouete_offset")
         column.operator("object.curve_remove_doubles")
         column.operator("object.mesh_get_pockets")

--- a/scripts/addons/cam/ui.py
+++ b/scripts/addons/cam/ui.py
@@ -45,7 +45,7 @@ class VIEW3D_PT_tools_curvetools(Panel):
         layout.operator("object.curve_intarsion")
         layout.operator("object.curve_overcuts")
         layout.operator("object.curve_overcuts_b")
-        layout.operator("object.silhouete")
+        #layout.operator("object.silhouete")
         layout.operator("object.silhouete_offset")
         layout.operator("object.curve_remove_doubles")
         layout.operator("object.mesh_get_pockets")


### PR DESCRIPTION
This PR doing
1- Adding an option to remove curve doubles to keep bezier or not.
2- Adding ( ok_cancel ) popup window to some classes. To prevent computing the default settings. Some times it take long time to calculate unwanted settings.
3- Fix get pocket
4- Remove (object_ silhouette ) since (silhouette_offset ) is working for objects.