### PR TITLE
STL & Outline Fill Fixes

### DIFF
--- a/scripts/addons/cam/basrelief.py
+++ b/scripts/addons/cam/basrelief.py
@@ -750,7 +750,7 @@ def renderScene(width, height, bit_diameter, passes_per_radius, make_nodes, view
         nodes.remove(our_renderer)
     if our_viewer is not None:
         nodes.remove(our_viewer)
-    bpy.context.scene.render.engine = 'BLENDERCAM_RENDER'
+    bpy.context.scene.render.engine = 'CNCCAM_RENDER'
     print("Done Rendering")
 
 
@@ -1217,7 +1217,7 @@ class BASRELIEF_Panel(bpy.types.Panel):
     bl_region_type = "WINDOW"
     bl_context = "render"
 
-    COMPAT_ENGINES = {'BLENDERCAM_RENDER'}
+    COMPAT_ENGINES = {'CNCCAM_RENDER'}
 
     # def draw_header(self, context):
     #   self.layout.menu("CAM_CUTTER_MT_presets", text="CAM Cutter")

--- a/scripts/addons/cam/image_utils.py
+++ b/scripts/addons/cam/image_utils.py
@@ -1212,7 +1212,7 @@ def renderSampleImage(o):
                     print("Failed to Backup Scene Settings")
 
             i = bpy.data.images.load(iname)
-            bpy.context.scene.render.engine = 'BLENDERCAM_RENDER'
+            bpy.context.scene.render.engine = 'CNCCAM_RENDER'
 
         a = imagetonumpy(i)
         a = 10.0 * a

--- a/scripts/addons/cam/image_utils.py
+++ b/scripts/addons/cam/image_utils.py
@@ -21,7 +21,7 @@ import numpy
 
 import bpy
 try:
-    import curve_simplify
+    import bl_ext.blender_org.simplify_curves_plus as curve_simplify
 except ImportError:
     pass
 

--- a/scripts/addons/cam/opencamlib/oclSample.py
+++ b/scripts/addons/cam/opencamlib/oclSample.py
@@ -17,7 +17,7 @@ except ImportError:
         pass
 
 try:
-    from io_mesh_stl import blender_utils
+    from bl_ext.blender_org.stl_format_legacy import blender_utils
 except ImportError:
     pass
 

--- a/scripts/addons/cam/pattern.py
+++ b/scripts/addons/cam/pattern.py
@@ -317,7 +317,7 @@ def getPathPattern(operation):
     # pathchunks=sortChunks(pathchunks,o)not until they get hierarchy parents!
     elif o.strategy == 'OUTLINEFILL':
 
-        polys = o.silhouete
+        polys = o.silhouete.geoms
         pathchunks = []
         chunks = []
         for p in polys:

--- a/scripts/addons/cam/pattern.py
+++ b/scripts/addons/cam/pattern.py
@@ -317,7 +317,7 @@ def getPathPattern(operation):
     # pathchunks=sortChunks(pathchunks,o)not until they get hierarchy parents!
     elif o.strategy == 'OUTLINEFILL':
 
-        polys = operation.silhouete
+        polys = o.silhouete
         pathchunks = []
         chunks = []
         for p in polys:

--- a/scripts/addons/cam/polygon_utils_cam.py
+++ b/scripts/addons/cam/polygon_utils_cam.py
@@ -11,7 +11,7 @@ from shapely import geometry as sgeometry
 
 from mathutils import Euler, Vector
 try:
-    import curve_simplify
+    import bl_ext.blender_org.simplify_curves_plus as curve_simplify
 except ImportError:
     pass
 

--- a/scripts/addons/cam/strategy.py
+++ b/scripts/addons/cam/strategy.py
@@ -512,7 +512,7 @@ async def pocket(o):
                     rothelix.reverse()
 
                     covers = False
-                    for poly in o.silhouete:
+                    for poly in o.silhouete.geoms:
                         if poly.contains(coutline):
                             covers = True
                             break

--- a/scripts/addons/cam/strategy.py
+++ b/scripts/addons/cam/strategy.py
@@ -433,7 +433,7 @@ async def pocket(o):
                     checkc = Circle(helix_radius + c_offset, o.optimisation.circle_detail)
                     checkc = affinity.translate(checkc, p[0], p[1])
                     covers = False
-                    for poly in o.silhouete:
+                    for poly in o.silhouete.geoms:
                         if poly.contains(checkc):
                             covers = True
                             break

--- a/scripts/addons/cam/ui_panels/buttons_panel.py
+++ b/scripts/addons/cam/ui_panels/buttons_panel.py
@@ -15,7 +15,7 @@ class CAMButtonsPanel:
     bl_region_type = 'WINDOW'
     bl_context = "render"
     always_show_panel = False
-    COMPAT_ENGINES = {'BLENDERCAM_RENDER'}
+    COMPAT_ENGINES = {'CNCCAM_RENDER'}
 
     # COMPAT_ENGINES must be defined in each subclass, external engines can add themselves here
 

--- a/scripts/addons/cam/ui_panels/pack.py
+++ b/scripts/addons/cam/ui_panels/pack.py
@@ -15,7 +15,7 @@ class CAM_PACK_Panel(CAMButtonsPanel, Panel):
     bl_idname = "WORLD_PT_CAM_PACK"
     panel_interface_level = 2
 
-    COMPAT_ENGINES = {'BLENDERCAM_RENDER'}
+    COMPAT_ENGINES = {'CNCCAM_RENDER'}
 
     def draw(self, context):
         layout = self.layout

--- a/scripts/addons/cam/ui_panels/slice.py
+++ b/scripts/addons/cam/ui_panels/slice.py
@@ -15,7 +15,7 @@ class CAM_SLICE_Panel(CAMButtonsPanel, Panel):
     bl_idname = "WORLD_PT_CAM_SLICE"
     panel_interface_level = 2
 
-    COMPAT_ENGINES = {'BLENDERCAM_RENDER'}
+    COMPAT_ENGINES = {'CNCCAM_RENDER'}
 
     def draw(self, context):
         layout = self.layout


### PR DESCRIPTION
STL operations had broken due to the addon naming change in 4.2, this updates the code to use the new name.

shapely changed how they handled MultiPolygons - previously you could loop through a `MultiPolygon` to get to its points, but now you have to specify `MultiPolygon.geoms` in order to get a list that you can loop through.

This cause the Outline Fill strategy to fail, it has now been fixed.