### PR TITLE
increase bezeir resolution before operations

### DIFF
--- a/scripts/addons/cam/curvecamtools.py
+++ b/scripts/addons/cam/curvecamtools.py
@@ -612,10 +612,10 @@ class CamCurveRemoveDoubles(Operator):
                 if self.keep_bezier:
                     bpy.ops.curvetools.operatorsplinesremoveshort()
                     bpy.context.view_layer.objects.active = ob
+                    ob.data.resolution_u = 64
                     if bpy.context.mode == 'OBJECT':
                         bpy.ops.object.editmode_toggle()
                     bpy.ops.curve.select_all()
-                    bpy.ops.curve.spline_type_set(type='BEZIER')
                     bpy.ops.curve.remove_double(distance=self.merg_distance)
                     bpy.ops.object.editmode_toggle()
                 else:


### PR DESCRIPTION
when cutting a bezier curve it was giving polygon like shape.
usually I increase resolution manually. now it is done.
operations  remove doubles, silhouette offset, cutout, pocket and medialaxis increase resolution if bezeir