### PR TITLE
Added Bug Report, Feature Request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Help us fix the bugs!
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the Bug**
+_A clear and concise description of what the bug is._
+
+**To Reproduce**
+_Steps to reproduce the behavior:_
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected Behavior**
+_A clear and concise description of what you expected to happen._
+
+**Screenshots**
+_If applicable, add screenshots to help explain your problem._
+
+**System Information:**
+ - OS: [e.g. Win10, Win11, MacOS Mojave, Debian, Arch, Fedora etc]
+ - Blender Version: [e.g. 3.6, 4.2.1]
+ - Addon Version: [e.g. 1.0.38]
+
+**Error Message:**
+_Copy and Paste the text of the error message here, it helps us to fix the bug faster._
+
+**Additional context**
+_Add any other context about the problem here._

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: ''
+assignees: ''
+
+---
+
+**How many jobs have you run with BlenderCAM?**
+_1-5, 5-10, 10+_
+
+**Is your feature request related to a problem? Please describe.**
+_A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]_
+
+**Describe the solution you'd like**
+_A clear and concise description of what you want to happen._
+
+**Describe alternatives you've considered**
+_A clear and concise description of any alternative solutions or features you've considered._
+
+**Additional context**
+_Add any other context or screenshots about the feature request here._


### PR DESCRIPTION
After seeing some requests come through the matrix chat, I figured it was worth it to set up templates for Bug Reports and Feature Requests.

They are mostly just the standard templates, but:
- the Bug Report has been tweaked to ask for more specific OS, Blender and Addon version info and the Error Message
- the Feature Request asks how many jobs you have run using BlenderCAM to get an idea of the users' experience level