### PR TITLE
Fix name 'unit_value_to_string' is not defined error

### DIFF
--- a/scripts/addons/cam/utilities/operation_utils.py
+++ b/scripts/addons/cam/utilities/operation_utils.py
@@ -12,6 +12,7 @@ import bpy
 from bpy_extras import object_utils
 
 from .simple_utils import get_cache_path
+from .simple_utils import unit_value_to_string
 
 from ..constants import was_hidden_dict
 


### PR DESCRIPTION
Fixes the following error:

  utilities/operation_utils.py", line 328, in update_chipload
      o.info.chipload_per_tooth = unit_value_to_string(o.info.chipload, 4)
                                  ^^^^^^^^^^^^^^^^^^^^
  NameError: name 'unit_value_to_string' is not defined
  File "utilities/operation_utils.py", line 346, in update_offset_image