### PR TITLE
fixed a few typos that prevented new machines from being defined

### DIFF
--- a/scripts/addons/fabex/operators/preset_ops.py
+++ b/scripts/addons/fabex/operators/preset_ops.py
@@ -161,13 +161,13 @@ class AddPresetCamMachine(AddPresetBase, Operator):
         "d.spindle_min",
         "d.spindle_max",
         "d.spindle_default",
-        "d.axis4",
-        "d.axis5",
+        "d.axis_4",
+        "d.axis_5",
         "d.collet_size",
         "d.output_tool_change",
         "d.output_block_numbers",
         "d.output_tool_definitions",
-        "d.output_g43_on_tool_change",
+        "d.output_G43_on_tool_change",
     ]
 
     preset_subdir = "cam_machines"


### PR DESCRIPTION
preset_ops.py had a mis-named machine property names that caused an error to be thrown when defining a new machine.

This is a simple first request to see if I understand the process.  Please let me know if there are best practices you'd like followed.

Thanks!