### PR TITLE
change medial axis strategy to create uniquely named pocket operations

### DIFF
--- a/scripts/addons/fabex/strategy.py
+++ b/scripts/addons/fabex/strategy.py
@@ -87,13 +87,13 @@ def add_pocket(maxdepth, sname, new_cutter_diameter):
     bpy.ops.object.select_all(action="DESELECT")
     s = bpy.context.scene
     mpocket_exists = False
-    mp_ob_name = "{}_medial_pocket".format(sname)
+    mp_ob_name = f"{sname}_medial_pocket"
     for ob in s.objects:  # delete old medial pocket
         if ob.name.startswith(mp_ob_name):
             ob.select_set(True)
             bpy.ops.object.delete()
 
-    mp_op_name = "{}_MedialPocket".format(sname)
+    mp_op_name = f"{sname}_MedialPocket"
     for op in s.cam_operations:  # verify medial pocket operation exists
         if op.name == mp_op_name:
             mpocket_exists = True

--- a/scripts/addons/fabex/strategy.py
+++ b/scripts/addons/fabex/strategy.py
@@ -87,28 +87,30 @@ def add_pocket(maxdepth, sname, new_cutter_diameter):
     bpy.ops.object.select_all(action="DESELECT")
     s = bpy.context.scene
     mpocket_exists = False
+    mp_ob_name = "{}_medial_pocket".format(sname)
     for ob in s.objects:  # delete old medial pocket
-        if ob.name.startswith("medial_poc"):
+        if ob.name.startswith(mp_ob_name):
             ob.select_set(True)
             bpy.ops.object.delete()
 
+    mp_op_name = "{}_MedialPocket".format(sname)
     for op in s.cam_operations:  # verify medial pocket operation exists
-        if op.name == "MedialPocket":
+        if op.name == mp_op_name:
             mpocket_exists = True
     ob = bpy.data.objects[sname]
     ob.select_set(True)
     bpy.context.view_layer.objects.active = ob
     silhouette_offset(ob, -new_cutter_diameter / 2, 1, 2)
-    bpy.context.active_object.name = "medial_pocket"
+    bpy.context.active_object.name = mp_ob_name
     m_ob = bpy.context.view_layer.objects.active
     bpy.ops.object.origin_set(type="ORIGIN_GEOMETRY", center="BOUNDS")
     m_ob.location.z = maxdepth
     if not mpocket_exists:  # create a pocket operation if it does not exist already
         s.cam_operations.add()
         o = s.cam_operations[-1]
-        o.object_name = "medial_pocket"
+        o.object_name = mp_ob_name
         s.cam_active_operation = len(s.cam_operations) - 1
-        o.name = "MedialPocket"
+        o.name = mp_op_name
         o.filename = o.name
         o.strategy = "POCKET"
         o.use_layers = False


### PR DESCRIPTION
Original medial axis strategy would create a "medial_pocket" object when adding a derivative pocket. Multiple medial axis operations in a single file will therefore conflict. This PR changes the strategy to create new pockets using the name of the object that it is derived from: "[original_obj]_medial_pocket", avoiding this conflict.

Similarly, newly created pocket operations follow a similar naming convention: "[original_obj]_MedialPocket" as opposed to just "MedialPocket".