### PR TITLE
Fixed chain operation ordering

### DIFF
--- a/fabex/utilities/operation_utils.py
+++ b/fabex/utilities/operation_utils.py
@@ -522,7 +522,7 @@ def get_chain_operations(chain):
     #             chop.append(so)\
 
     operations = bpy.context.scene.cam_operations
-    chop = [so for so in operations for cho in chain.operations if so.name == cho.name]
+    chop = [so for cho in chain.operations for so in operations if so.name == cho.name]
     return chop
 
 


### PR DESCRIPTION
Reverse the ordering of the iterators collecting the operations for a chain, this fixes the ordering as defined by the user in the chain list.

Fixes #266 

Actually, the original commented-out code right above this comprehension seems to be just fine, and is more readable, should we maybe just put that back in place?