### PR TITLE
fixed dedupe_points() for small objects

### DIFF
--- a/fabex/chunk_builder.py
+++ b/fabex/chunk_builder.py
@@ -273,10 +273,9 @@ class CamPathChunk:
 
     def dedupe_points(self):
         if len(self.points) > 1:
-            # Fix from vukhanhtrung
             diffs = np.sum((self.points[1:] - self.points[:-1]) ** 2, axis=1)
             keep_points = np.ones(len(self.points), dtype=bool)
-            keep_points[1:] = diffs > 1e-9
+            keep_points[1:] = diffs > 1e-12
 
             self.points = self.points[keep_points, :]
 


### PR DESCRIPTION
dedupe_points() uses a magical constant `1e-9` to determine the distance of points considered duplicates; this causes points to be dropped too eagerly on smallish objects (few mm or cm in size).

Reducing to `1e-12` solves the issue, assuming no one will be CNCing in the micrometer domain anytime soon.